### PR TITLE
Add client and employee management pages

### DIFF
--- a/client/src/Admin/AdminDashboard.tsx
+++ b/client/src/Admin/AdminDashboard.tsx
@@ -21,8 +21,8 @@ export default function AdminDashboard() {
         <Routes>
           <Route index element={<Home />} />
           <Route path="calendar" element={<Calendar />} />
-          <Route path="clients" element={<Clients />} />
-          <Route path="employees" element={<Employees />} />
+          <Route path="clients/*" element={<Clients />} />
+          <Route path="employees/*" element={<Employees />} />
           <Route path="financing" element={<Financing />} />
         </Routes>
       </main>

--- a/client/src/Admin/pages/Clients.tsx
+++ b/client/src/Admin/pages/Clients.tsx
@@ -1,9 +1,140 @@
-import React from 'react'
+import { useState, useEffect, useRef } from 'react'
+import { Routes, Route, Link, useNavigate, useParams } from 'react-router-dom'
+
+interface Client {
+  id: number
+  name: string
+  number: string
+  address: string
+  notes?: string
+}
+
+function List() {
+  const [items, setItems] = useState<Client[]>([])
+  const [search, setSearch] = useState('')
+  const [page, setPage] = useState(0)
+  const [hasMore, setHasMore] = useState(true)
+  const loader = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    setItems([])
+    setPage(0)
+    setHasMore(true)
+  }, [search])
+
+  useEffect(() => {
+    load()
+  }, [page, search])
+
+  function load() {
+    fetch(`http://localhost:3000/clients?search=${encodeURIComponent(search)}&skip=${page * 20}&take=20`)
+      .then((r) => r.json())
+      .then((data: Client[]) => {
+        setItems((prev) => [...prev, ...data])
+        if (data.length < 20) setHasMore(false)
+      })
+  }
+
+  useEffect(() => {
+    const obs = new IntersectionObserver((entries) => {
+      if (entries[0].isIntersecting && hasMore) {
+        setPage((p) => p + 1)
+      }
+    })
+    if (loader.current) obs.observe(loader.current)
+    return () => {
+      if (loader.current) obs.unobserve(loader.current)
+    }
+  }, [hasMore])
+
+  return (
+    <div className="p-4">
+      <h2 className="text-xl font-semibold mb-2">Clients</h2>
+      <div className="flex items-center gap-2 mb-4">
+        <input
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Search by name or number"
+          className="flex-1 border p-2 rounded"
+        />
+        <Link to="new" className="bg-blue-500 text-white px-3 py-1 rounded text-sm">
+          New
+        </Link>
+      </div>
+      <ul className="divide-y">
+        {items.map((c) => (
+          <li key={c.id} className="py-2">
+            <Link to={String(c.id)} className="block">
+              <div className="font-medium">{c.name}</div>
+              <div className="text-sm text-gray-600">{c.number}</div>
+            </Link>
+          </li>
+        ))}
+      </ul>
+      <div ref={loader} className="h-5" />
+    </div>
+  )
+}
+
+function Form() {
+  const { id } = useParams()
+  const navigate = useNavigate()
+  const isNew = id === undefined
+  const [data, setData] = useState<Client>({ id: 0, name: '', number: '', address: '', notes: '' })
+
+  useEffect(() => {
+    if (!isNew) {
+      fetch(`http://localhost:3000/clients/${id}`)
+        .then((r) => r.json())
+        .then((d) => setData(d))
+    }
+  }, [id, isNew])
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    setData({ ...data, [e.target.name]: e.target.value })
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    await fetch(`http://localhost:3000/clients${isNew ? '' : '/' + id}`, {
+      method: isNew ? 'POST' : 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    })
+    navigate('..')
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="p-4 space-y-3">
+      <div>
+        <label className="block text-sm">Name</label>
+        <input name="name" value={data.name} onChange={handleChange} className="w-full border p-2 rounded" />
+      </div>
+      <div>
+        <label className="block text-sm">Number</label>
+        <input name="number" value={data.number} onChange={handleChange} className="w-full border p-2 rounded" />
+      </div>
+      <div>
+        <label className="block text-sm">Address</label>
+        <input name="address" value={data.address} onChange={handleChange} className="w-full border p-2 rounded" />
+      </div>
+      <div>
+        <label className="block text-sm">Notes</label>
+        <textarea name="notes" value={data.notes || ''} onChange={handleChange} className="w-full border p-2 rounded" />
+      </div>
+      <button className="bg-blue-500 text-white px-4 py-2 rounded" type="submit">
+        Save
+      </button>
+    </form>
+  )
+}
 
 export default function Clients() {
   return (
-    <div className="p-4">
-      <h2 className="text-xl font-semibold">Clients</h2>
-    </div>
+    <Routes>
+      <Route index element={<List />} />
+      <Route path="new" element={<Form />} />
+      <Route path=":id" element={<Form />} />
+    </Routes>
   )
 }

--- a/client/src/Admin/pages/Employees.tsx
+++ b/client/src/Admin/pages/Employees.tsx
@@ -1,9 +1,140 @@
-import React from 'react'
+import { useState, useEffect, useRef } from 'react'
+import { Routes, Route, Link, useNavigate, useParams } from 'react-router-dom'
+
+interface Employee {
+  id: number
+  name: string
+  number: string
+  address: string
+  notes?: string
+}
+
+function List() {
+  const [items, setItems] = useState<Employee[]>([])
+  const [search, setSearch] = useState('')
+  const [page, setPage] = useState(0)
+  const [hasMore, setHasMore] = useState(true)
+  const loader = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    setItems([])
+    setPage(0)
+    setHasMore(true)
+  }, [search])
+
+  useEffect(() => {
+    load()
+  }, [page, search])
+
+  function load() {
+    fetch(`http://localhost:3000/employees?search=${encodeURIComponent(search)}&skip=${page * 20}&take=20`)
+      .then((r) => r.json())
+      .then((data: Employee[]) => {
+        setItems((prev) => [...prev, ...data])
+        if (data.length < 20) setHasMore(false)
+      })
+  }
+
+  useEffect(() => {
+    const obs = new IntersectionObserver((entries) => {
+      if (entries[0].isIntersecting && hasMore) {
+        setPage((p) => p + 1)
+      }
+    })
+    if (loader.current) obs.observe(loader.current)
+    return () => {
+      if (loader.current) obs.unobserve(loader.current)
+    }
+  }, [hasMore])
+
+  return (
+    <div className="p-4">
+      <h2 className="text-xl font-semibold mb-2">Employees</h2>
+      <div className="flex items-center gap-2 mb-4">
+        <input
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Search by name or number"
+          className="flex-1 border p-2 rounded"
+        />
+        <Link to="new" className="bg-blue-500 text-white px-3 py-1 rounded text-sm">
+          New
+        </Link>
+      </div>
+      <ul className="divide-y">
+        {items.map((c) => (
+          <li key={c.id} className="py-2">
+            <Link to={String(c.id)} className="block">
+              <div className="font-medium">{c.name}</div>
+              <div className="text-sm text-gray-600">{c.number}</div>
+            </Link>
+          </li>
+        ))}
+      </ul>
+      <div ref={loader} className="h-5" />
+    </div>
+  )
+}
+
+function Form() {
+  const { id } = useParams()
+  const navigate = useNavigate()
+  const isNew = id === undefined
+  const [data, setData] = useState<Employee>({ id: 0, name: '', number: '', address: '', notes: '' })
+
+  useEffect(() => {
+    if (!isNew) {
+      fetch(`http://localhost:3000/employees/${id}`)
+        .then((r) => r.json())
+        .then((d) => setData(d))
+    }
+  }, [id, isNew])
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    setData({ ...data, [e.target.name]: e.target.value })
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    await fetch(`http://localhost:3000/employees${isNew ? '' : '/' + id}`, {
+      method: isNew ? 'POST' : 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    })
+    navigate('..')
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="p-4 space-y-3">
+      <div>
+        <label className="block text-sm">Name</label>
+        <input name="name" value={data.name} onChange={handleChange} className="w-full border p-2 rounded" />
+      </div>
+      <div>
+        <label className="block text-sm">Number</label>
+        <input name="number" value={data.number} onChange={handleChange} className="w-full border p-2 rounded" />
+      </div>
+      <div>
+        <label className="block text-sm">Address</label>
+        <input name="address" value={data.address} onChange={handleChange} className="w-full border p-2 rounded" />
+      </div>
+      <div>
+        <label className="block text-sm">Notes</label>
+        <textarea name="notes" value={data.notes || ''} onChange={handleChange} className="w-full border p-2 rounded" />
+      </div>
+      <button className="bg-blue-500 text-white px-4 py-2 rounded" type="submit">
+        Save
+      </button>
+    </form>
+  )
+}
 
 export default function Employees() {
   return (
-    <div className="p-4">
-      <h2 className="text-xl font-semibold">Employees</h2>
-    </div>
+    <Routes>
+      <Route index element={<List />} />
+      <Route path="new" element={<Form />} />
+      <Route path=":id" element={<Form />} />
+    </Routes>
   )
 }

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -12,3 +12,103 @@ model User {
   email String @unique
   name  String?
 }
+
+model Client {
+  id                   Int                    @id @default(autoincrement())
+  name                 String                 @unique
+  number               String
+  address              String
+  notes                String?
+  appointments         Appointment[]
+  appointmentTemplates AppointmentTemplate[]
+}
+
+model Employee {
+  id           Int                        @id @default(autoincrement())
+  name         String                     @unique
+  number       String
+  address      String
+  notes        String?
+  appointments Appointment[]              @relation("AppointmentEmployees")
+
+  templateLinks EmployeeTemplateEmployee[] @relation("EmployeeOnTemplate")
+}
+
+model Appointment {
+  id              Int             @id @default(autoincrement())
+  date            DateTime
+  time            String
+  clientId        Int
+  client          Client          @relation(fields: [clientId], references: [id])
+  type            AppointmentType
+  address         String
+  cityStateZip    String?
+  size            String?
+  price           Float?
+  paid            Boolean         @default(false)
+  paymentMethod   PaymentMethod
+  tip             Float           @default(0)
+  reoccurring     Boolean         @default(false)
+  lineage         String
+  gateCode        String?
+  doorCode        String?
+  buildingNumber  String?
+  notes           String?
+  createdAt       DateTime?       @default(now())
+  updatedAt       DateTime?       @updatedAt
+
+  employees       Employee[]      @relation("AppointmentEmployees")
+}
+
+model AppointmentTemplate {
+  id                Int                @id @default(autoincrement())
+  templateName      String
+  type              AppointmentType
+  size              String?
+  address           String
+  cityStateZip      String?
+  price             Float
+  clientId          Int
+  client            Client             @relation(fields: [clientId], references: [id])
+  employeeTemplates EmployeeTemplate[]
+  createdAt         DateTime?          @default(now())
+  updatedAt         DateTime?          @updatedAt
+}
+
+model EmployeeTemplate {
+  id                    Int                       @id @default(autoincrement())
+  templateName          String
+  appointmentTemplateId Int
+  appointmentTemplate   AppointmentTemplate       @relation(fields: [appointmentTemplateId], references: [id], onDelete: Cascade)
+  employees             EmployeeTemplateEmployee[]
+  totalPrice            Float                     @default(0)
+
+  createdAt             DateTime?                 @default(now())
+  updatedAt             DateTime?                 @updatedAt
+}
+
+model EmployeeTemplateEmployee {
+  id                 Int       @id @default(autoincrement())
+  employeeId         Int
+  price              Float
+
+  employeeTemplateId Int
+  employeeTemplate   EmployeeTemplate @relation(fields: [employeeTemplateId], references: [id])
+
+  employee           Employee @relation("EmployeeOnTemplate", fields: [employeeId], references: [id])
+}
+
+enum PaymentMethod {
+  ZELLE
+  VENMO
+  CASH
+  PAYPAL
+  CHECK
+  OTHER
+}
+
+enum AppointmentType {
+  STANDARD
+  DEEP
+  MOVE_IN_OUT
+}

--- a/server/prisma/seed.ts
+++ b/server/prisma/seed.ts
@@ -9,6 +9,20 @@ async function main() {
       name: 'Alice'
     }
   })
+
+  await prisma.client.createMany({
+    data: [
+      { name: 'John Doe', number: '555-1111', address: '123 Main St' },
+      { name: 'Jane Smith', number: '555-2222', address: '456 Oak Ave' }
+    ]
+  })
+
+  await prisma.employee.createMany({
+    data: [
+      { name: 'Emp One', number: '555-3333', address: '789 Pine Rd' },
+      { name: 'Emp Two', number: '555-4444', address: '321 Cedar Ln' }
+    ]
+  })
 }
 
 main()

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -24,6 +24,95 @@ app.get('/users', async (_req: Request, res: Response) => {
   res.json(users)
 })
 
+app.get('/clients', async (req: Request, res: Response) => {
+  const search = (req.query.search as string) || ''
+  const skip = parseInt((req.query.skip as string) || '0', 10)
+  const take = parseInt((req.query.take as string) || '20', 10)
+
+  const where = search
+    ? {
+        OR: [
+          { name: { contains: search, mode: 'insensitive' } },
+          { number: { contains: search, mode: 'insensitive' } },
+        ],
+      }
+    : {}
+
+  const clients = await prisma.client.findMany({ where, skip, take, orderBy: { name: 'asc' } })
+  res.json(clients)
+})
+
+app.post('/clients', async (req: Request, res: Response) => {
+  try {
+    const clientData = req.body
+    const client = await prisma.client.create({ data: clientData })
+    res.json(client)
+  } catch (e) {
+    res.status(500).json({ error: 'Failed to create client' })
+  }
+})
+
+app.get('/clients/:id', async (req: Request, res: Response) => {
+  const id = parseInt(req.params.id, 10)
+  const client = await prisma.client.findUnique({ where: { id } })
+  if (!client) return res.status(404).json({ error: 'Not found' })
+  res.json(client)
+})
+
+app.put('/clients/:id', async (req: Request, res: Response) => {
+  const id = parseInt(req.params.id, 10)
+  try {
+    const client = await prisma.client.update({ where: { id }, data: req.body })
+    res.json(client)
+  } catch (e) {
+    res.status(500).json({ error: 'Failed to update client' })
+  }
+})
+
+app.get('/employees', async (req: Request, res: Response) => {
+  const search = (req.query.search as string) || ''
+  const skip = parseInt((req.query.skip as string) || '0', 10)
+  const take = parseInt((req.query.take as string) || '20', 10)
+
+  const where = search
+    ? {
+        OR: [
+          { name: { contains: search, mode: 'insensitive' } },
+          { number: { contains: search, mode: 'insensitive' } },
+        ],
+      }
+    : {}
+
+  const employees = await prisma.employee.findMany({ where, skip, take, orderBy: { name: 'asc' } })
+  res.json(employees)
+})
+
+app.post('/employees', async (req: Request, res: Response) => {
+  try {
+    const employee = await prisma.employee.create({ data: req.body })
+    res.json(employee)
+  } catch (e) {
+    res.status(500).json({ error: 'Failed to create employee' })
+  }
+})
+
+app.get('/employees/:id', async (req: Request, res: Response) => {
+  const id = parseInt(req.params.id, 10)
+  const employee = await prisma.employee.findUnique({ where: { id } })
+  if (!employee) return res.status(404).json({ error: 'Not found' })
+  res.json(employee)
+})
+
+app.put('/employees/:id', async (req: Request, res: Response) => {
+  const id = parseInt(req.params.id, 10)
+  try {
+    const employee = await prisma.employee.update({ where: { id }, data: req.body })
+    res.json(employee)
+  } catch (e) {
+    res.status(500).json({ error: 'Failed to update employee' })
+  }
+})
+
 app.post('/login', async (req: Request, res: Response) => {
   const { token } = req.body
   if (!token) {


### PR DESCRIPTION
## Summary
- extend prisma schema with client/employee models
- seed initial clients and employees
- expose CRUD endpoints in the Express server
- add admin pages for managing clients and employees with search and lazy loading
- adjust admin routing for nested routes

## Testing
- `npm run build` in `server`
- `npm run build` in `client`


------
https://chatgpt.com/codex/tasks/task_e_6874c8739e3c832db36bf054ef212ece