### PR TITLE
Fix client/employee creation and phone validation

### DIFF
--- a/client/src/Admin/pages/Clients.tsx
+++ b/client/src/Admin/pages/Clients.tsx
@@ -2,10 +2,9 @@ import { useState, useEffect, useRef } from 'react'
 import { Routes, Route, Link, useNavigate, useParams } from 'react-router-dom'
 
 interface Client {
-  id: number
+  id?: number
   name: string
   number: string
-  address: string
   notes?: string
 }
 
@@ -80,7 +79,7 @@ function Form() {
   const { id } = useParams()
   const navigate = useNavigate()
   const isNew = id === undefined
-  const [data, setData] = useState<Client>({ id: 0, name: '', number: '', address: '', notes: '' })
+  const [data, setData] = useState<Client>({ name: '', number: '', notes: '' })
 
   useEffect(() => {
     if (!isNew) {
@@ -96,10 +95,11 @@ function Form() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
+    const payload = { name: data.name, number: data.number, notes: data.notes }
     await fetch(`http://localhost:3000/clients${isNew ? '' : '/' + id}`, {
       method: isNew ? 'POST' : 'PUT',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(data),
+      body: JSON.stringify(payload),
     })
     navigate('..')
   }
@@ -113,10 +113,6 @@ function Form() {
       <div>
         <label className="block text-sm">Number</label>
         <input name="number" value={data.number} onChange={handleChange} className="w-full border p-2 rounded" />
-      </div>
-      <div>
-        <label className="block text-sm">Address</label>
-        <input name="address" value={data.address} onChange={handleChange} className="w-full border p-2 rounded" />
       </div>
       <div>
         <label className="block text-sm">Notes</label>

--- a/client/src/Admin/pages/Employees.tsx
+++ b/client/src/Admin/pages/Employees.tsx
@@ -2,10 +2,9 @@ import { useState, useEffect, useRef } from 'react'
 import { Routes, Route, Link, useNavigate, useParams } from 'react-router-dom'
 
 interface Employee {
-  id: number
+  id?: number
   name: string
   number: string
-  address: string
   notes?: string
 }
 
@@ -80,7 +79,7 @@ function Form() {
   const { id } = useParams()
   const navigate = useNavigate()
   const isNew = id === undefined
-  const [data, setData] = useState<Employee>({ id: 0, name: '', number: '', address: '', notes: '' })
+  const [data, setData] = useState<Employee>({ name: '', number: '', notes: '' })
 
   useEffect(() => {
     if (!isNew) {
@@ -96,10 +95,11 @@ function Form() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
+    const payload = { name: data.name, number: data.number, notes: data.notes }
     await fetch(`http://localhost:3000/employees${isNew ? '' : '/' + id}`, {
       method: isNew ? 'POST' : 'PUT',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(data),
+      body: JSON.stringify(payload),
     })
     navigate('..')
   }
@@ -113,10 +113,6 @@ function Form() {
       <div>
         <label className="block text-sm">Number</label>
         <input name="number" value={data.number} onChange={handleChange} className="w-full border p-2 rounded" />
-      </div>
-      <div>
-        <label className="block text-sm">Address</label>
-        <input name="address" value={data.address} onChange={handleChange} className="w-full border p-2 rounded" />
       </div>
       <div>
         <label className="block text-sm">Notes</label>

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -17,7 +17,6 @@ model Client {
   id                   Int                    @id @default(autoincrement())
   name                 String                 @unique
   number               String
-  address              String
   notes                String?
   appointments         Appointment[]
   appointmentTemplates AppointmentTemplate[]
@@ -27,7 +26,6 @@ model Employee {
   id           Int                        @id @default(autoincrement())
   name         String                     @unique
   number       String
-  address      String
   notes        String?
   appointments Appointment[]              @relation("AppointmentEmployees")
 

--- a/server/prisma/seed.ts
+++ b/server/prisma/seed.ts
@@ -12,15 +12,15 @@ async function main() {
 
   await prisma.client.createMany({
     data: [
-      { name: 'John Doe', number: '555-1111', address: '123 Main St' },
-      { name: 'Jane Smith', number: '555-2222', address: '456 Oak Ave' }
+      { name: 'John Doe', number: '5551111111' },
+      { name: 'Jane Smith', number: '5552222222' }
     ]
   })
 
   await prisma.employee.createMany({
     data: [
-      { name: 'Emp One', number: '555-3333', address: '789 Pine Rd' },
-      { name: 'Emp Two', number: '555-4444', address: '321 Cedar Ln' }
+      { name: 'Emp One', number: '5553333333' },
+      { name: 'Emp Two', number: '5554444444' }
     ]
   })
 }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -57,8 +57,18 @@ app.get('/clients', async (req: Request, res: Response) => {
 
 app.post('/clients', async (req: Request, res: Response) => {
   try {
-    const clientData = req.body
-    const client = await prisma.client.create({ data: clientData })
+    const { name, number, notes } = req.body as {
+      name?: string
+      number?: string
+      notes?: string
+    }
+    if (!name || !number) {
+      return res.status(400).json({ error: 'Name and number are required' })
+    }
+    if (!/^\d{10}$/.test(number)) {
+      return res.status(400).json({ error: 'Number must be 10 digits' })
+    }
+    const client = await prisma.client.create({ data: { name, number, notes } })
     res.json(client)
   } catch (e) {
     res.status(500).json({ error: 'Failed to create client' })
@@ -75,7 +85,21 @@ app.get('/clients/:id', async (req: Request, res: Response) => {
 app.put('/clients/:id', async (req: Request, res: Response) => {
   const id = parseInt(req.params.id, 10)
   try {
-    const client = await prisma.client.update({ where: { id }, data: req.body })
+    const { name, number, notes } = req.body as {
+      name?: string
+      number?: string
+      notes?: string
+    }
+    const data: Prisma.ClientUpdateInput = {}
+    if (name !== undefined) data.name = name
+    if (number !== undefined) {
+      if (!/^\d{10}$/.test(number)) {
+        return res.status(400).json({ error: 'Number must be 10 digits' })
+      }
+      data.number = number
+    }
+    if (notes !== undefined) data.notes = notes
+    const client = await prisma.client.update({ where: { id }, data })
     res.json(client)
   } catch (e) {
     res.status(500).json({ error: 'Failed to update client' })
@@ -112,7 +136,18 @@ app.get('/employees', async (req: Request, res: Response) => {
 
 app.post('/employees', async (req: Request, res: Response) => {
   try {
-    const employee = await prisma.employee.create({ data: req.body })
+    const { name, number, notes } = req.body as {
+      name?: string
+      number?: string
+      notes?: string
+    }
+    if (!name || !number) {
+      return res.status(400).json({ error: 'Name and number are required' })
+    }
+    if (!/^\d{10}$/.test(number)) {
+      return res.status(400).json({ error: 'Number must be 10 digits' })
+    }
+    const employee = await prisma.employee.create({ data: { name, number, notes } })
     res.json(employee)
   } catch (e) {
     res.status(500).json({ error: 'Failed to create employee' })
@@ -129,7 +164,21 @@ app.get('/employees/:id', async (req: Request, res: Response) => {
 app.put('/employees/:id', async (req: Request, res: Response) => {
   const id = parseInt(req.params.id, 10)
   try {
-    const employee = await prisma.employee.update({ where: { id }, data: req.body })
+    const { name, number, notes } = req.body as {
+      name?: string
+      number?: string
+      notes?: string
+    }
+    const data: Prisma.EmployeeUpdateInput = {}
+    if (name !== undefined) data.name = name
+    if (number !== undefined) {
+      if (!/^\d{10}$/.test(number)) {
+        return res.status(400).json({ error: 'Number must be 10 digits' })
+      }
+      data.number = number
+    }
+    if (notes !== undefined) data.notes = notes
+    const employee = await prisma.employee.update({ where: { id }, data })
     res.json(employee)
   } catch (e) {
     res.status(500).json({ error: 'Failed to update employee' })


### PR DESCRIPTION
## Summary
- remove `address` fields from client and employee models
- adjust seed data accordingly
- validate phone numbers and required fields in server API
- strip ID and address fields from admin client/employee forms

## Testing
- `npm run build` (fails: Prisma types missing after `prisma generate` was blocked)
- `npm run lint` in client (fails: ESLint config errors)
- `npm run build` in client

------
https://chatgpt.com/codex/tasks/task_e_6874ce976604832d87741c30b90b1899