### PR TITLE
Implement mobile bottom nav and agenda calendar

### DIFF
--- a/client/src/Admin/AdminDashboard.tsx
+++ b/client/src/Admin/AdminDashboard.tsx
@@ -8,7 +8,7 @@ import Financing from './pages/Financing'
 export default function AdminDashboard() {
   return (
     <div className="min-h-screen bg-gray-100 text-gray-900">
-      <nav className="bg-white shadow mb-4">
+      <nav className="bg-white shadow md:mb-4 fixed bottom-0 w-full md:static">
         <ul className="flex flex-wrap justify-around p-2 text-sm">
           <li><Link className="px-2 py-1" to="/dashboard">Home</Link></li>
           <li><Link className="px-2 py-1" to="/dashboard/calendar">Calendar</Link></li>
@@ -17,7 +17,7 @@ export default function AdminDashboard() {
           <li><Link className="px-2 py-1" to="/dashboard/financing">Financing</Link></li>
         </ul>
       </nav>
-      <main>
+      <main className="flex-1 pb-16 md:pb-0">
         <Routes>
           <Route index element={<Home />} />
           <Route path="calendar" element={<Calendar />} />

--- a/client/src/Admin/pages/Calendar.tsx
+++ b/client/src/Admin/pages/Calendar.tsx
@@ -1,9 +1,47 @@
-import React from 'react'
+import { useState } from 'react'
+
+function startOfWeek(date: Date) {
+  const day = date.getDay()
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate() - day)
+}
+
+function addDays(date: Date, days: number) {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate() + days)
+}
 
 export default function Calendar() {
+  const [selected, setSelected] = useState(new Date())
+  const weekStart = startOfWeek(selected)
+  const days = Array.from({ length: 7 }).map((_, i) => addDays(weekStart, i))
   return (
-    <div className="p-4">
-      <h2 className="text-xl font-semibold">Calendar</h2>
+    <div className="flex flex-col h-full">
+      <div className="p-2 text-center font-semibold border-b">
+        {selected.toLocaleString('default', { month: 'long', year: 'numeric' })}
+      </div>
+      <div className="grid grid-cols-7 text-center border-b">
+        {days.map((day) => {
+          const isSelected = day.toDateString() === selected.toDateString()
+          return (
+            <button
+              key={day.toDateString()}
+              onClick={() => setSelected(day)}
+              className={`p-1 ${isSelected ? 'bg-blue-500 text-white' : 'hover:bg-gray-200'}`}
+            >
+              <div className="text-xs">
+                {day.toLocaleDateString('default', { weekday: 'short' })}
+              </div>
+              <div className="text-sm font-medium">{day.getDate()}</div>
+            </button>
+          )
+        })}
+      </div>
+      <div className="flex-1 overflow-y-auto divide-y">
+        {Array.from({ length: 24 }).map((_, i) => (
+          <div key={i} className="h-12 px-2">
+            <span className="text-xs text-gray-500">{String(i).padStart(2, '0')}:00</span>
+          </div>
+        ))}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- move the admin navigation to the bottom on mobile
- add padding so content isn't hidden behind the nav
- implement calendar with month header, week selector and hourly agenda

## Testing
- `npm run lint` *(fails: Parsing error)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6874d6bf56ac832d99db2b0bd0c01695