### PR TITLE
Improve calendar interactions and design

### DIFF
--- a/client/src/Admin/pages/Calendar.tsx
+++ b/client/src/Admin/pages/Calendar.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 function startOfWeek(date: Date) {
   const day = date.getDay()
@@ -11,14 +11,48 @@ function addDays(date: Date, days: number) {
 
 export default function Calendar() {
   const [selected, setSelected] = useState(new Date())
+  const [showMonth, setShowMonth] = useState(false)
+  const [nowOffset, setNowOffset] = useState<number | null>(null)
+
   const weekStart = startOfWeek(selected)
   const days = Array.from({ length: 7 }).map((_, i) => addDays(weekStart, i))
+
+  const monthStart = new Date(selected.getFullYear(), selected.getMonth(), 1)
+  const monthEnd = new Date(selected.getFullYear(), selected.getMonth() + 1, 0)
+  const monthDays = Array.from({ length: monthEnd.getDate() }).map((_, i) =>
+    new Date(selected.getFullYear(), selected.getMonth(), i + 1)
+  )
+
+  useEffect(() => {
+    const now = new Date()
+    const offset = now.getHours() * 84 + (now.getMinutes() / 60) * 84
+    setNowOffset(offset)
+  }, [])
   return (
     <div className="flex flex-col h-full">
-      <div className="p-2 text-center font-semibold border-b">
+      <div
+        className="p-2 text-center font-semibold border-b cursor-pointer"
+        onClick={() => setShowMonth((v) => !v)}
+      >
         {selected.toLocaleString('default', { month: 'long', year: 'numeric' })}
       </div>
-      <div className="grid grid-cols-7 text-center border-b">
+      <div
+        className={`grid grid-cols-7 text-center border-b overflow-hidden transition-all duration-300 ${showMonth ? 'max-h-96' : 'max-h-0'}`}
+      >
+        {monthDays.map((day) => (
+          <button
+            key={day.toDateString()}
+            onClick={() => {
+              setSelected(day)
+              setShowMonth(false)
+            }}
+            className={`p-1 ${day.toDateString() === selected.toDateString() ? 'bg-blue-500 text-white' : 'hover:bg-gray-200'}`}
+          >
+            {day.getDate()}
+          </button>
+        ))}
+      </div>
+      <div className={`grid grid-cols-7 text-center border-b ${showMonth ? 'hidden' : ''}`}>
         {days.map((day) => {
           const isSelected = day.toDateString() === selected.toDateString()
           return (
@@ -35,10 +69,20 @@ export default function Calendar() {
           )
         })}
       </div>
-      <div className="flex-1 overflow-y-auto divide-y">
+      <div className="flex-1 overflow-y-auto relative pt-2 divide-y">
+        {nowOffset !== null && (
+          <div
+            className="absolute left-0 right-0 h-px bg-red-500"
+            style={{ top: nowOffset }}
+          />
+        )}
         {Array.from({ length: 24 }).map((_, i) => (
-          <div key={i} className="h-12 px-2">
-            <span className="text-xs text-gray-500">{String(i).padStart(2, '0')}:00</span>
+          <div key={i} className="h-[84px] grid grid-cols-[4rem_1fr] px-2">
+            <div className="text-xs text-gray-500 pr-2 border-r flex items-start justify-end">
+              {new Date(0, 0, 0, i)
+                .toLocaleString('en-US', { hour: 'numeric', hour12: true })}
+            </div>
+            <div className="" />
           </div>
         ))}
       </div>


### PR DESCRIPTION
## Summary
- show a dropdown month picker when clicking the month
- support selecting any day from the month picker
- display time slots at 84px high with AM/PM formatting
- add padding and a vertical separator for the time column
- draw a red line indicating the current time

## Testing
- `npm run lint` *(fails: Parsing error)*
- `npm run build`
- `npm run build` in server *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_6874dac11058832d8960e4807e953f98