### PR TITLE
Enhance calendar month view

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -24,6 +24,24 @@ app.get('/users', async (_req: Request, res: Response) => {
   res.json(users)
 })
 
+app.get('/month-info', (req: Request, res: Response) => {
+  const year = parseInt(String(req.query.year))
+  const month = parseInt(String(req.query.month))
+
+  if (Number.isNaN(year) || Number.isNaN(month)) {
+    return res.status(400).json({ error: 'Invalid year or month' })
+  }
+
+  const first = new Date(year, month - 1, 1)
+  const last = new Date(year, month, 0)
+
+  res.json({
+    startDay: first.getDay(),
+    endDay: last.getDay(),
+    daysInMonth: last.getDate(),
+  })
+})
+
 app.get('/clients', async (req: Request, res: Response) => {
   // 1. Pull and normalize query params
   const searchTerm = String(req.query.search || '').trim()


### PR DESCRIPTION
## Summary
- expose new `/month-info` endpoint to supply calendar metadata
- fetch metadata from the client calendar page
- show a collapsible month grid with weekday header
- add arrow icon for toggling month view
- remove spacing between week view and hour blocks

## Testing
- `npm run build` in `client`
- `npm run build` in `server` *(fails: Prisma binaries blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6874dd67f1dc832da5c1699ab08f9f1d