### PR TITLE
Fix calendar nav overlay

### DIFF
--- a/client/src/Admin/AdminDashboard.tsx
+++ b/client/src/Admin/AdminDashboard.tsx
@@ -8,7 +8,7 @@ import Financing from './pages/financing/Financing'
 export default function AdminDashboard() {
   return (
     <div className="min-h-screen bg-gray-100 text-gray-900">
-      <nav className="bg-white shadow md:mb-4 fixed bottom-0 w-full md:static">
+      <nav className="bg-white shadow md:mb-4 fixed bottom-0 w-full md:static z-10">
         <ul className="flex flex-wrap justify-around p-2 text-sm">
           <li><Link className="px-2 py-1" to="/dashboard">Home</Link></li>
           <li><Link className="px-2 py-1" to="/dashboard/calendar">Calendar</Link></li>


### PR DESCRIPTION
## Summary
- ensure navigation bar sits above page content

## Testing
- `npm run lint` *(fails: Parsing error)*
- `npm test` in server *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6874ec0fdebc832db66b1cf7b0e71db7