### PR TITLE
Implement swipeable monthly calendar view

### DIFF
--- a/client/src/Admin/AdminDashboard.tsx
+++ b/client/src/Admin/AdminDashboard.tsx
@@ -1,8 +1,8 @@
 import { Link, Routes, Route } from 'react-router-dom'
 import Home from './pages/home/Home'
-import Calendar from './pages/calendar'
-import Clients from './pages/clients'
-import Employees from './pages/employees'
+import Calendar from './pages/Calendar'
+import Clients from './pages/Clients'
+import Employees from './pages/Employees'
 import Financing from './pages/financing/Financing'
 
 export default function AdminDashboard() {

--- a/client/src/Admin/pages/Calendar/components/MonthSelector.tsx
+++ b/client/src/Admin/pages/Calendar/components/MonthSelector.tsx
@@ -1,19 +1,62 @@
-import { useRef } from 'react'
-
-interface MonthInfo {
-  startDay: number
-  endDay: number
-  daysInMonth: number
-}
+import { useEffect, useRef, useState } from 'react'
 
 interface Props {
   selected: Date
   setSelected: (d: Date) => void
   show: boolean
   setShow: (v: boolean) => void
-  monthInfo: MonthInfo | null
+  monthInfo: { startDay: number; endDay: number; daysInMonth: number } | null
   prevMonth: () => void
   nextMonth: () => void
+}
+
+function getPaddedMonthDays(date: Date) {
+  const start = new Date(date.getFullYear(), date.getMonth(), 1)
+  const end = new Date(date.getFullYear(), date.getMonth() + 1, 0)
+  const days = Array.from({ length: end.getDate() }).map(
+    (_, i) => new Date(date.getFullYear(), date.getMonth(), i + 1)
+  )
+  const startPad = start.getDay()
+  const endPad = 6 - end.getDay()
+  return [
+    ...Array.from({ length: startPad }).map(() => null as Date | null),
+    ...days,
+    ...Array.from({ length: endPad }).map(() => null as Date | null),
+  ]
+}
+
+type MonthGridProps = {
+  days: (Date | null)[]
+  selected: Date
+  setSelected: (d: Date) => void
+  setShow: (v: boolean) => void
+}
+
+function MonthGrid({ days, selected, setSelected, setShow }: MonthGridProps) {
+  return (
+    <div className="grid grid-cols-7 text-center flex-shrink-0 w-full">
+      {days.map((day, idx) =>
+        day ? (
+          <button
+            key={day.toDateString()}
+            onClick={() => {
+              setSelected(day)
+              setShow(false)
+            }}
+            className={`p-1 ${
+              day.toDateString() === selected.toDateString()
+                ? 'bg-blue-500 text-white'
+                : 'hover:bg-gray-200'
+            }`}
+          >
+            {day.getDate()}
+          </button>
+        ) : (
+          <div key={idx} className="p-1" />
+        )
+      )}
+    </div>
+  )
 }
 
 export default function MonthSelector({
@@ -25,22 +68,88 @@ export default function MonthSelector({
   prevMonth,
   nextMonth,
 }: Props) {
-  const monthTouchStart = useRef<number | null>(null)
+  const containerRef = useRef<HTMLDivElement>(null)
+  const touchStartX = useRef<number | null>(null)
+  const [dragOffset, setDragOffset] = useState(0)
+  const [translate, setTranslate] = useState(-100)
+  const [animating, setAnimating] = useState(false)
 
-  const monthStart = new Date(selected.getFullYear(), selected.getMonth(), 1)
-  const monthEnd = new Date(selected.getFullYear(), selected.getMonth() + 1, 0)
-  const monthDays = Array.from({ length: monthEnd.getDate() }).map((_, i) =>
-    new Date(selected.getFullYear(), selected.getMonth(), i + 1)
-  )
+  useEffect(() => {
+    // reset position when selected month changes via buttons
+    setTranslate(-100)
+  }, [selected])
 
-  const paddedMonthDays = (() => {
-    const startPad = monthInfo ? monthInfo.startDay : monthStart.getDay()
-    const endPad = monthInfo ? 6 - monthInfo.endDay : 6 - monthEnd.getDay()
-    return [
-      ...Array.from({ length: startPad }).map(() => null as Date | null),
-      ...monthDays,
-      ...Array.from({ length: endPad }).map(() => null as Date | null),
-    ]
+  const prevDate = new Date(selected.getFullYear(), selected.getMonth() - 1, 1)
+  const nextDate = new Date(selected.getFullYear(), selected.getMonth() + 1, 1)
+
+  const prevDays = getPaddedMonthDays(prevDate)
+  const currentDays = getPaddedMonthDays(selected)
+  const nextDays = getPaddedMonthDays(nextDate)
+
+  const handleTouchStart = (e: React.TouchEvent) => {
+    touchStartX.current = e.touches[0].clientX
+    setDragOffset(0)
+    setAnimating(false)
+  }
+
+  const handleTouchMove = (e: React.TouchEvent) => {
+    if (touchStartX.current == null || !containerRef.current) return
+    const diff = e.touches[0].clientX - touchStartX.current
+    const pct = (diff / containerRef.current.offsetWidth) * 100
+    setDragOffset(pct)
+  }
+
+  const handleTouchEnd = () => {
+    if (touchStartX.current == null || !containerRef.current) return
+    const diffPx = (dragOffset / 100) * containerRef.current.offsetWidth
+    if (Math.abs(diffPx) > 50) {
+      setAnimating(true)
+      if (diffPx < 0) {
+        // swipe left -> next month
+        setTranslate(-200)
+        setTimeout(() => {
+          setAnimating(false)
+          setTranslate(-100)
+          nextMonth()
+        }, 300)
+      } else {
+        setTranslate(0)
+        setTimeout(() => {
+          setAnimating(false)
+          setTranslate(-100)
+          prevMonth()
+        }, 300)
+      }
+    } else {
+      setAnimating(true)
+      setDragOffset(0)
+      setTimeout(() => {
+        setAnimating(false)
+        setDragOffset(0)
+      }, 300)
+    }
+    touchStartX.current = null
+  }
+
+  const style = {
+    transform: `translateX(calc(${translate}% + ${dragOffset}%))`,
+    transition: animating ? 'transform 0.3s ease' : undefined,
+  }
+
+  const paddedCurrent = (() => {
+    if (monthInfo) {
+      const startPad = monthInfo.startDay
+      const endPad = 6 - monthInfo.endDay
+      const monthDays = Array.from({ length: monthInfo.daysInMonth }).map(
+        (_, i) => new Date(selected.getFullYear(), selected.getMonth(), i + 1)
+      )
+      return [
+        ...Array.from({ length: startPad }).map(() => null as Date | null),
+        ...monthDays,
+        ...Array.from({ length: endPad }).map(() => null as Date | null),
+      ]
+    }
+    return currentDays
   })()
 
   return (
@@ -83,44 +192,40 @@ export default function MonthSelector({
       <div
         className={`border-b overflow-hidden transition-[max-height] duration-300 ${show ? 'max-h-96' : 'max-h-0'}`}
       >
-        <div
-          className="grid grid-cols-7 text-center"
-          onTouchStart={(e) => {
-            monthTouchStart.current = e.touches[0].clientX
-          }}
-          onTouchEnd={(e) => {
-            if (monthTouchStart.current !== null) {
-              const diff = e.changedTouches[0].clientX - monthTouchStart.current
-              if (Math.abs(diff) > 50) {
-                diff < 0 ? nextMonth() : prevMonth()
-              }
-              monthTouchStart.current = null
-            }
-          }}
-        >
+        <div className="grid grid-cols-7 text-center">
           {['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'].map((d) => (
             <div key={d} className="p-1 text-xs font-medium">
               {d}
             </div>
           ))}
         </div>
-        <div className="grid grid-cols-7 text-center">
-          {paddedMonthDays.map((day, idx) =>
-            day ? (
-              <button
-                key={day.toDateString()}
-                onClick={() => {
-                  setSelected(day)
-                  setShow(false)
-                }}
-                className={`p-1 ${day.toDateString() === selected.toDateString() ? 'bg-blue-500 text-white' : 'hover:bg-gray-200'}`}
-              >
-                {day.getDate()}
-              </button>
-            ) : (
-              <div key={idx} className="p-1" />
-            )
-          )}
+        <div
+          className="overflow-hidden touch-pan-x"
+          ref={containerRef}
+          onTouchStart={handleTouchStart}
+          onTouchMove={handleTouchMove}
+          onTouchEnd={handleTouchEnd}
+        >
+          <div className="flex w-[300%]" style={style}>
+            <MonthGrid
+              days={prevDays}
+              selected={selected}
+              setSelected={setSelected}
+              setShow={setShow}
+            />
+            <MonthGrid
+              days={paddedCurrent}
+              selected={selected}
+              setSelected={setSelected}
+              setShow={setShow}
+            />
+            <MonthGrid
+              days={nextDays}
+              selected={selected}
+              setSelected={setSelected}
+              setShow={setShow}
+            />
+          </div>
         </div>
       </div>
     </>


### PR DESCRIPTION
## Summary
- fix case-sensitive imports in Admin dashboard
- preload prev/next months and animate swiping in MonthSelector

## Testing
- `npm run build` in `client`
- `npm run build` in `server` *(fails: Prisma types missing)*

------
https://chatgpt.com/codex/tasks/task_e_6874f2960844832d8c8cdb6a73a3407c