### PR TITLE
Add appointment creation modal

### DIFF
--- a/client/src/Admin/AdminDashboard.tsx
+++ b/client/src/Admin/AdminDashboard.tsx
@@ -1,9 +1,9 @@
 import { Link, Routes, Route } from 'react-router-dom'
-import Home from './pages/Home/Home'
+import Home from './pages/home/Home'
 import Calendar from './pages/Calendar'
 import Clients from './pages/Clients'
 import Employees from './pages/Employees'
-import Financing from './pages/Financing/Financing'
+import Financing from './pages/financing/Financing'
 
 export default function AdminDashboard() {
   return (

--- a/client/src/Admin/pages/Calendar/components/CreateAppointmentModal.tsx
+++ b/client/src/Admin/pages/Calendar/components/CreateAppointmentModal.tsx
@@ -1,0 +1,324 @@
+import { useEffect, useState } from 'react'
+import { Client } from '../../Clients/components/types'
+import type { AppointmentTemplate } from '../types'
+
+interface Props {
+  onClose: () => void
+  onCreated: () => void
+}
+
+const sizeOptions = [
+  '0-1000',
+  '1000-1500',
+  '1500-2000',
+  '2000-2500',
+  '2500-3000',
+  '3000-3500',
+  '3500-4000',
+  '4000-4500',
+  '4500-5000',
+  '5500-6000',
+  '6000+',
+]
+
+export default function CreateAppointmentModal({ onClose, onCreated }: Props) {
+  const [clientSearch, setClientSearch] = useState('')
+  const [clients, setClients] = useState<Client[]>([])
+  const [selectedClient, setSelectedClient] = useState<Client | null>(null)
+  const [newClient, setNewClient] = useState({ name: '', number: '', notes: '' })
+  const [showNewClient, setShowNewClient] = useState(false)
+
+  const [templates, setTemplates] = useState<AppointmentTemplate[]>([])
+  const [selectedTemplate, setSelectedTemplate] = useState<number | null>(null)
+  const [showNewTemplate, setShowNewTemplate] = useState(false)
+  const [templateForm, setTemplateForm] = useState({
+    templateName: '',
+    type: 'STANDARD',
+    size: '',
+    address: '',
+    price: '',
+    notes: '',
+  })
+
+  const [date, setDate] = useState('')
+  const [time, setTime] = useState('')
+
+  // Load clients when search changes
+  useEffect(() => {
+    fetch(
+      `http://localhost:3000/clients?search=${encodeURIComponent(
+        clientSearch
+      )}&skip=0&take=20`
+    )
+      .then((r) => r.json())
+      .then((d) => setClients(d))
+  }, [clientSearch])
+
+  // Load templates when client selected
+  useEffect(() => {
+    if (!selectedClient) {
+      setTemplates([])
+      setSelectedTemplate(null)
+      return
+    }
+    fetch(`http://localhost:3000/appointment-templates?clientId=${selectedClient.id}`)
+      .then((r) => r.json())
+      .then((d) => setTemplates(d))
+  }, [selectedClient])
+
+  const createClient = async () => {
+    const res = await fetch('http://localhost:3000/clients', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(newClient),
+    })
+    if (res.ok) {
+      const c = await res.json()
+      setSelectedClient(c)
+      setShowNewClient(false)
+      setClientSearch('')
+    } else {
+      alert('Failed to create client')
+    }
+  }
+
+  const createTemplate = async () => {
+    if (!selectedClient) return
+    const payload = {
+      clientId: selectedClient.id,
+      templateName: templateForm.templateName,
+      type: templateForm.type,
+      size: templateForm.size || undefined,
+      address: templateForm.address,
+      price: parseFloat(templateForm.price),
+      notes: templateForm.notes || undefined,
+    }
+    const res = await fetch('http://localhost:3000/appointment-templates', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    })
+    if (res.ok) {
+      const t = await res.json()
+      setTemplates((p) => [...p, t])
+      setSelectedTemplate(t.id)
+      setShowNewTemplate(false)
+    } else {
+      alert('Failed to create template')
+    }
+  }
+
+  const createAppointment = async () => {
+    if (!selectedClient || !selectedTemplate) return
+    const res = await fetch('http://localhost:3000/appointments', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        clientId: selectedClient.id,
+        templateId: selectedTemplate,
+        date,
+        time,
+      }),
+    })
+    if (res.ok) {
+      onCreated()
+      onClose()
+    } else {
+      alert('Failed to create appointment')
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-20">
+      <div className="bg-white p-4 rounded w-96 max-h-full overflow-y-auto space-y-4">
+        <div className="flex justify-between items-center">
+          <h2 className="text-lg font-semibold">New Appointment</h2>
+          <button onClick={onClose}>X</button>
+        </div>
+
+        {/* Client selection */}
+        {selectedClient ? (
+          <div>
+            <div className="flex items-center justify-between mb-2">
+              <div className="font-medium">Client: {selectedClient.name}</div>
+              <button className="text-sm text-blue-500" onClick={() => setSelectedClient(null)}>
+                change
+              </button>
+            </div>
+          </div>
+        ) : showNewClient ? (
+          <div className="space-y-2 border p-2 rounded">
+            <input
+              className="w-full border p-1 rounded"
+              placeholder="Name"
+              value={newClient.name}
+              onChange={(e) => setNewClient({ ...newClient, name: e.target.value })}
+            />
+            <input
+              className="w-full border p-1 rounded"
+              placeholder="Number"
+              value={newClient.number}
+              onChange={(e) => setNewClient({ ...newClient, number: e.target.value })}
+            />
+            <textarea
+              className="w-full border p-1 rounded"
+              placeholder="Notes"
+              value={newClient.notes}
+              onChange={(e) => setNewClient({ ...newClient, notes: e.target.value })}
+            />
+            <div className="flex gap-2 justify-end">
+              <button className="px-2" onClick={() => setShowNewClient(false)}>
+                Cancel
+              </button>
+              <button className="px-2 text-blue-600" onClick={createClient}>
+                Save
+              </button>
+            </div>
+          </div>
+        ) : (
+          <div>
+            <div className="flex gap-2 mb-1">
+              <input
+                className="flex-1 border p-1 rounded"
+                placeholder="Search clients"
+                value={clientSearch}
+                onChange={(e) => setClientSearch(e.target.value)}
+              />
+              <button className="px-2 text-sm" onClick={() => setShowNewClient(true)}>
+                New
+              </button>
+            </div>
+            <ul className="max-h-32 overflow-y-auto border rounded">
+              {clients.map((c) => (
+                <li key={c.id} className="p-1 hover:bg-gray-100 cursor-pointer" onClick={() => setSelectedClient(c)}>
+                  {c.name}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {/* Template selection */}
+        {selectedClient && (
+          <div>
+            {selectedTemplate ? (
+              <div className="flex items-center justify-between mb-2">
+                <div className="font-medium">
+                  Template: {templates.find((t) => t.id === selectedTemplate)?.templateName}
+                </div>
+                <button className="text-sm text-blue-500" onClick={() => setSelectedTemplate(null)}>
+                  change
+                </button>
+              </div>
+            ) : showNewTemplate ? (
+              <div className="space-y-2 border p-2 rounded">
+                <input
+                  className="w-full border p-1 rounded"
+                  placeholder="Name"
+                  value={templateForm.templateName}
+                  onChange={(e) => setTemplateForm({ ...templateForm, templateName: e.target.value })}
+                />
+                <select
+                  className="w-full border p-1 rounded"
+                  value={templateForm.type}
+                  onChange={(e) => setTemplateForm({ ...templateForm, type: e.target.value })}
+                >
+                  <option value="DEEP">Deep</option>
+                  <option value="MOVE_IN_OUT">Move in/out</option>
+                  <option value="STANDARD">Standard</option>
+                </select>
+                <select
+                  className="w-full border p-1 rounded"
+                  value={templateForm.size}
+                  onChange={(e) => setTemplateForm({ ...templateForm, size: e.target.value })}
+                >
+                  <option value="">Select size</option>
+                  {sizeOptions.map((s) => (
+                    <option key={s} value={s}>
+                      {s}
+                    </option>
+                  ))}
+                </select>
+                <input
+                  className="w-full border p-1 rounded"
+                  placeholder="Price"
+                  type="number"
+                  value={templateForm.price}
+                  onChange={(e) => setTemplateForm({ ...templateForm, price: e.target.value })}
+                />
+                <input
+                  className="w-full border p-1 rounded"
+                  placeholder="Address"
+                  value={templateForm.address}
+                  onChange={(e) => setTemplateForm({ ...templateForm, address: e.target.value })}
+                />
+                <textarea
+                  className="w-full border p-1 rounded"
+                  placeholder="Notes"
+                  value={templateForm.notes}
+                  onChange={(e) => setTemplateForm({ ...templateForm, notes: e.target.value })}
+                />
+                <div className="flex gap-2 justify-end">
+                  <button className="px-2" onClick={() => setShowNewTemplate(false)}>
+                    Cancel
+                  </button>
+                  <button className="px-2 text-blue-600" onClick={createTemplate}>
+                    Save
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <div>
+                <div className="flex gap-2 mb-1">
+                  <select
+                    className="flex-1 border p-1 rounded"
+                    value={selectedTemplate ?? ''}
+                    onChange={(e) => setSelectedTemplate(Number(e.target.value))}
+                  >
+                    <option value="">Select template</option>
+                    {templates.map((t) => (
+                      <option key={t.id} value={t.id}>
+                        {t.templateName}
+                      </option>
+                    ))}
+                  </select>
+                  <button className="px-2 text-sm" onClick={() => setShowNewTemplate(true)}>
+                    New
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Date and time */}
+        {selectedTemplate && (
+          <div className="space-y-2">
+            <input
+              type="date"
+              className="w-full border p-1 rounded"
+              value={date}
+              onChange={(e) => setDate(e.target.value)}
+            />
+            <input
+              type="time"
+              className="w-full border p-1 rounded"
+              value={time}
+              onChange={(e) => setTime(e.target.value)}
+            />
+          </div>
+        )}
+
+        <div className="text-right">
+          <button
+            className="bg-blue-500 text-white px-4 py-1 rounded disabled:opacity-50"
+            disabled={!selectedTemplate || !date || !time}
+            onClick={createAppointment}
+          >
+            Create
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/client/src/Admin/pages/Calendar/components/DayTimeline.tsx
+++ b/client/src/Admin/pages/Calendar/components/DayTimeline.tsx
@@ -1,12 +1,18 @@
-import { useRef, useState } from "react";
+import { useRef, useState } from 'react'
+import type { Appointment } from '../types'
 
 interface Props {
-  nowOffset: number | null;
-  prevDay: () => void;
-  nextDay: () => void;
+  nowOffset: number | null
+  prevDay: () => void
+  nextDay: () => void
+  appointments: Appointment[]
 }
-
-export default function DayTimeline({ nowOffset, prevDay, nextDay }: Props) {
+export default function DayTimeline({
+  nowOffset,
+  prevDay,
+  nextDay,
+  appointments,
+}: Props) {
   const dayTouchStart = useRef<number | null>(null);
   const [dayDragX, setDayDragX] = useState<number | null>(null);
   const [dragDirection, setDragDirection] = useState<"left" | "right" | null>(null);
@@ -120,14 +126,28 @@ export default function DayTimeline({ nowOffset, prevDay, nextDay }: Props) {
       {Array.from({ length: 24 }).map((_, i) => (
         <div key={i} className="h-[84px] grid grid-cols-[4rem_1fr] px-2">
           <div className="text-xs text-gray-500 pr-2 border-r flex items-start justify-end">
-            {new Date(0, 0, 0, i).toLocaleString("en-US", {
-              hour: "numeric",
+            {new Date(0, 0, 0, i).toLocaleString('en-US', {
+              hour: 'numeric',
               hour12: true,
             })}
           </div>
           <div />
         </div>
       ))}
+
+      {appointments.map((a) => {
+        const [h, m] = a.time.split(':').map((n) => parseInt(n, 10))
+        const top = h * 84 + (m / 60) * 84
+        return (
+          <div
+            key={a.id}
+            className="absolute left-16 right-2 h-8 bg-blue-200 border border-blue-400 rounded px-1 text-xs overflow-hidden"
+            style={{ top }}
+          >
+            {a.type}
+          </div>
+        )
+      })}
     </div>
   );
 }

--- a/client/src/Admin/pages/Calendar/types.ts
+++ b/client/src/Admin/pages/Calendar/types.ts
@@ -1,0 +1,22 @@
+export interface AppointmentTemplate {
+  id?: number
+  templateName: string
+  type: 'STANDARD' | 'DEEP' | 'MOVE_IN_OUT'
+  size?: string
+  address: string
+  price: number
+  clientId: number
+  cityStateZip?: string // used for notes
+}
+
+export interface Appointment {
+  id?: number
+  date: string
+  time: string
+  clientId: number
+  type: 'STANDARD' | 'DEEP' | 'MOVE_IN_OUT'
+  address: string
+  size?: string
+  price?: number
+  notes?: string
+}


### PR DESCRIPTION
## Summary
- add appointment/template endpoints to the server
- allow creating appointments from the calendar view
- show appointment blocks on the day timeline
- fix imports for Admin dashboard

## Testing
- `npm run build` in `server`
- `npm run build` in `client`


------
https://chatgpt.com/codex/tasks/task_e_6874fa838d5c832d9aa12038b674c835