### PR TITLE
Add cancel and experienced field

### DIFF
--- a/client/src/Admin/pages/Employees/components/EmployeeForm.tsx
+++ b/client/src/Admin/pages/Employees/components/EmployeeForm.tsx
@@ -6,18 +6,29 @@ export default function EmployeeForm() {
   const { id } = useParams()
   const navigate = useNavigate()
   const isNew = id === undefined
-  const [data, setData] = useState<Employee>({ name: '', number: '', notes: '' })
+  const [data, setData] = useState<Employee>({
+    name: '',
+    number: '',
+    notes: '',
+    experienced: false,
+  })
 
   useEffect(() => {
     if (!isNew) {
       fetch(`http://localhost:3000/employees/${id}`)
         .then((r) => r.json())
-        .then((d) => setData(d))
+        .then((d) => setData({ experienced: false, ...d }))
     }
   }, [id, isNew])
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
     setData({ ...data, [e.target.name]: e.target.value })
+  }
+
+  const handleCheckboxChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setData({ ...data, experienced: e.target.checked })
   }
 
   const handleNumberChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -29,7 +40,12 @@ export default function EmployeeForm() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
-    const payload = { name: data.name, number: data.number, notes: data.notes }
+    const payload = {
+      name: data.name,
+      number: data.number,
+      notes: data.notes,
+      experienced: data.experienced,
+    }
     const res = await fetch(`http://localhost:3000/employees${isNew ? '' : '/' + id}` ,{
       method: isNew ? 'POST' : 'PUT',
       headers: { 'Content-Type': 'application/json' },
@@ -75,9 +91,27 @@ export default function EmployeeForm() {
         <label className="block text-sm">Notes</label>
         <textarea name="notes" value={data.notes || ''} onChange={handleChange} className="w-full border p-2 rounded" />
       </div>
-      <button className="bg-blue-500 text-white px-4 py-2 rounded" type="submit">
-        Save
-      </button>
+      <div className="flex items-center gap-2">
+        <input
+          id="experienced"
+          type="checkbox"
+          checked={data.experienced ?? false}
+          onChange={handleCheckboxChange}
+        />
+        <label htmlFor="experienced" className="text-sm">Experienced</label>
+      </div>
+      <div className="flex gap-2">
+        <button className="bg-blue-500 text-white px-4 py-2 rounded" type="submit">
+          Save
+        </button>
+        <button
+          type="button"
+          onClick={() => navigate('..')}
+          className="bg-gray-300 px-4 py-2 rounded"
+        >
+          Cancel
+        </button>
+      </div>
     </form>
   )
 }

--- a/client/src/Admin/pages/Employees/components/types.ts
+++ b/client/src/Admin/pages/Employees/components/types.ts
@@ -3,4 +3,5 @@ export interface Employee {
   name: string
   number: string
   notes?: string
+  experienced?: boolean
 }

--- a/server/prisma/migrations/20250715000000_add_experienced/migration.sql
+++ b/server/prisma/migrations/20250715000000_add_experienced/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Employee" ADD COLUMN "experienced" BOOLEAN NOT NULL DEFAULT false;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -27,6 +27,7 @@ model Employee {
   name         String                     @unique
   number       String
   notes        String?
+  experienced  Boolean                    @default(false)
   appointments Appointment[]              @relation("AppointmentEmployees")
 
   templateLinks EmployeeTemplateEmployee[] @relation("EmployeeOnTemplate")

--- a/server/prisma/seed.ts
+++ b/server/prisma/seed.ts
@@ -19,8 +19,8 @@ async function main() {
 
   await prisma.employee.createMany({
     data: [
-      { name: 'Emp One', number: '5553333333' },
-      { name: 'Emp Two', number: '5554444444' }
+      { name: 'Emp One', number: '5553333333', experienced: true },
+      { name: 'Emp Two', number: '5554444444', experienced: false }
     ]
   })
 }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -162,10 +162,11 @@ app.get('/employees', async (req: Request, res: Response) => {
 
 app.post('/employees', async (req: Request, res: Response) => {
   try {
-    const { name, number, notes } = req.body as {
+    const { name, number, notes, experienced } = req.body as {
       name?: string
       number?: string
       notes?: string
+      experienced?: boolean
     }
     if (!name || !number) {
       return res.status(400).json({ error: 'Name and number are required' })
@@ -173,7 +174,9 @@ app.post('/employees', async (req: Request, res: Response) => {
     if (!/^\d{10}$/.test(number)) {
       return res.status(400).json({ error: 'Number must be 10 digits' })
     }
-    const employee = await prisma.employee.create({ data: { name, number, notes } })
+    const employee = await prisma.employee.create({
+      data: { name, number, notes, experienced: experienced ?? false }
+    })
     res.json(employee)
   } catch (e) {
     res.status(500).json({ error: 'Failed to create employee' })
@@ -190,10 +193,11 @@ app.get('/employees/:id', async (req: Request, res: Response) => {
 app.put('/employees/:id', async (req: Request, res: Response) => {
   const id = parseInt(req.params.id, 10)
   try {
-    const { name, number, notes } = req.body as {
+    const { name, number, notes, experienced } = req.body as {
       name?: string
       number?: string
       notes?: string
+      experienced?: boolean
     }
     const data: any = {}
     if (name !== undefined) data.name = name
@@ -204,6 +208,7 @@ app.put('/employees/:id', async (req: Request, res: Response) => {
       data.number = number
     }
     if (notes !== undefined) data.notes = notes
+    if (experienced !== undefined) data.experienced = experienced
     const employee = await prisma.employee.update({ where: { id }, data })
     res.json(employee)
   } catch (e) {


### PR DESCRIPTION
## Summary
- add `experienced` to Employee schema and seed data
- generate a migration for the new field
- allow creating/updating employees with the new property
- extend EmployeeForm with checkbox and cancel button
- include `experienced` in client Employee type

## Testing
- `npm run build` in `server`
- `npx tsc --noEmit` *(fails: Property 'prevMonth' does not exist on type 'IntrinsicAttributes & Props'. Property 'env' does not exist on type 'ImportMeta')*

------
https://chatgpt.com/codex/tasks/task_e_687524b981a4832db3793a2abfe16a1a