### PR TITLE
Fix Google login redirect mode

### DIFF
--- a/client/src/Admin/pages/Calendar/components/CreateAppointmentModal.tsx
+++ b/client/src/Admin/pages/Calendar/components/CreateAppointmentModal.tsx
@@ -182,8 +182,9 @@ export default function CreateAppointmentModal({ onClose, onCreated }: Props) {
   }
 
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-20">
-      <div className="bg-white p-4 rounded w-96 max-h-full overflow-y-auto space-y-4">
+    <>
+      <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-20">
+        <div className="bg-white p-4 rounded w-96 max-h-full overflow-y-auto space-y-4">
         <div className="flex justify-between items-center">
           <h2 className="text-lg font-semibold">New Appointment</h2>
           <button onClick={onClose}>X</button>
@@ -472,6 +473,6 @@ export default function CreateAppointmentModal({ onClose, onCreated }: Props) {
         </div>
       </div>
     )}
-  </div>
+    </>
   )
 }

--- a/client/src/Landing/components/Login.tsx
+++ b/client/src/Landing/components/Login.tsx
@@ -40,7 +40,6 @@ export default function Login({ onLogin }: LoginProps) {
       <GoogleLogin
         onSuccess={handleGoogle}
         ux_mode="redirect"
-        redirect_uri={window.location.origin}
       />
     </div>
   )


### PR DESCRIPTION
## Summary
- remove unsupported `redirect_uri` prop from `<GoogleLogin>`
- wrap calendar appointment modal return in fragment to avoid JSX errors

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68755d099620832db3fd8b254f03c740