### PR TITLE
Fix google login redirect

### DIFF
--- a/client/src/Landing/components/Login.tsx
+++ b/client/src/Landing/components/Login.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { useGoogleLogin, TokenResponse } from '@react-oauth/google'
+import { useGoogleLogin, CodeResponse } from '@react-oauth/google'
 
 type Role = 'admin' | 'user'
 
@@ -17,17 +17,38 @@ export default function Login({ onLogin }: LoginProps) {
       onLogin(stored as Role)
       navigate('/dashboard')
     }
+    const params = new URLSearchParams(window.location.search)
+    const code = params.get('code')
+    if (code) {
+      ;(async () => {
+        const response = await fetch('http://localhost:3000/login', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ code })
+        })
+        const data = await response.json()
+        if (data.role) {
+          onLogin(data.role as Role)
+          localStorage.setItem('role', data.role)
+          navigate('/dashboard')
+        }
+        // remove code from url
+        params.delete('code')
+        const newUrl = `${window.location.pathname}${params.toString() ? '?' + params.toString() : ''}`
+        window.history.replaceState({}, '', newUrl)
+      })()
+    }
   }, [])
 
   const login = useGoogleLogin({
     ux_mode: 'redirect',
     redirect_uri: window.location.origin,
-    onSuccess: async (res: TokenResponse) => {
-      if (!res.access_token) return
+    flow: 'auth-code',
+    onSuccess: async (res: CodeResponse) => {
       const response = await fetch('http://localhost:3000/login', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ token: res.access_token })
+        body: JSON.stringify({ code: res.code })
       })
       const data = await response.json()
       if (data.role) {

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,3 +1,5 @@
 GOOGLE_CLIENT_ID=your-google-client-id
+GOOGLE_CLIENT_SECRET=your-google-client-secret
+GOOGLE_REDIRECT_URI=http://localhost:5173
 ADMIN_EMAILS=admin@example.com
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres

--- a/server/README.md
+++ b/server/README.md
@@ -4,4 +4,4 @@ This server uses Express with Prisma for database access. Run `npm install` and 
 
 The database connection string is configured via `.env` and a `docker-compose.yml` file is provided to start a local PostgreSQL instance.
 
-To enable Google authentication set `GOOGLE_CLIENT_ID` and `ADMIN_EMAILS` in your `.env` file. Emails listed in `ADMIN_EMAILS` (comma separated) will be treated as admins when logging in.
+To enable Google authentication set `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_REDIRECT_URI` and `ADMIN_EMAILS` in your `.env` file. Emails listed in `ADMIN_EMAILS` (comma separated) will be treated as admins when logging in.


### PR DESCRIPTION
## Summary
- ensure auth-code OAuth flow
- exchange code on the server for tokens
- require client secret and redirect URI in server env
- handle redirect code on client so dashboard loads

## Testing
- `npm --prefix client run build --silent`
- `npm --prefix server install --silent` *(fails: binaries.prisma.sh blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68756874cc9c832dbeca8a456f44706a