### PR TITLE
Fix OAuth2 getToken typings

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -379,7 +379,6 @@ app.post('/login', async (req: Request, res: Response) => {
       const { tokens } = await client.getToken({
         code,
         client_id: process.env.GOOGLE_CLIENT_ID,
-        client_secret: process.env.GOOGLE_CLIENT_SECRET,
         redirect_uri: process.env.GOOGLE_REDIRECT_URI || 'http://localhost:5173',
       })
       if (tokens.id_token) {


### PR DESCRIPTION
## Summary
- fix `client.getToken` invocation in `server/src/server.ts` for google-auth-library v10

## Testing
- `npm run build` in `server`

------
https://chatgpt.com/codex/tasks/task_e_6875de0e85a8832db753a78ae3aa4840