### PR TITLE
Fix API base URL for mobile use

### DIFF
--- a/client/.env.example
+++ b/client/.env.example
@@ -1,1 +1,2 @@
 VITE_GOOGLE_CLIENT_ID=your-google-client-id
+VITE_API_BASE_URL=http://localhost:3000

--- a/client/README.md
+++ b/client/README.md
@@ -7,4 +7,4 @@ This project was bootstrapped with [Vite](https://vitejs.dev/) and includes `tai
 - `npm install` – install dependencies
 - `npm run dev` – start the development server
 
-The app starts with a login page where you can sign in with Google. To enable Google sign-in provide `VITE_GOOGLE_CLIENT_ID` in an `.env` file.
+The app starts with a login page where you can sign in with Google. To enable Google sign-in provide `VITE_GOOGLE_CLIENT_ID` in an `.env` file. API requests are sent to `VITE_API_BASE_URL`, which defaults to `http://localhost:3000`.

--- a/client/eslint.config.js
+++ b/client/eslint.config.js
@@ -2,18 +2,22 @@ import js from '@eslint/js'
 import globals from 'globals'
 import reactHooks from 'eslint-plugin-react-hooks'
 import reactRefresh from 'eslint-plugin-react-refresh'
+import tseslint from 'typescript-eslint'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
 export default defineConfig([
   globalIgnores(['dist']),
   {
     files: ['**/*.{js,jsx,ts,tsx}'],
+    plugins: { '@typescript-eslint': tseslint.plugin },
     extends: [
       js.configs.recommended,
       reactHooks.configs['recommended-latest'],
       reactRefresh.configs.vite,
+      tseslint.configs.recommended,
     ],
     languageOptions: {
+      parser: tseslint.parser,
       ecmaVersion: 2020,
       globals: globals.browser,
       parserOptions: {

--- a/client/src/Admin/pages/Calendar/components/CreateAppointmentModal.tsx
+++ b/client/src/Admin/pages/Calendar/components/CreateAppointmentModal.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { Client } from '../../Clients/components/types'
 import type { AppointmentTemplate } from '../types'
 import type { Employee } from '../../Employees/components/types'
+import { API_BASE_URL } from '../../../../api'
 
 interface Props {
   onClose: () => void
@@ -69,7 +70,7 @@ export default function CreateAppointmentModal({ onClose, onCreated }: Props) {
   // Load clients when search changes
   useEffect(() => {
     fetch(
-      `http://localhost:3000/clients?search=${encodeURIComponent(
+      `${API_BASE_URL}/clients?search=${encodeURIComponent(
         clientSearch
       )}&skip=0&take=20`
     )
@@ -84,7 +85,7 @@ export default function CreateAppointmentModal({ onClose, onCreated }: Props) {
       setSelectedTemplate(null)
       return
     }
-    fetch(`http://localhost:3000/appointment-templates?clientId=${selectedClient.id}`)
+    fetch(`${API_BASE_URL}/appointment-templates?clientId=${selectedClient.id}`)
       .then((r) => r.json())
       .then((d) => setTemplates(d))
   }, [selectedClient])
@@ -97,19 +98,19 @@ export default function CreateAppointmentModal({ onClose, onCreated }: Props) {
     }
     const t = templates.find((tt) => tt.id === selectedTemplate)
     if (!t || !t.size) return
-    fetch(`http://localhost:3000/staff-options?size=${encodeURIComponent(t.size)}&type=${t.type}`)
+    fetch(`${API_BASE_URL}/staff-options?size=${encodeURIComponent(t.size)}&type=${t.type}`)
       .then((r) => r.json())
       .then((d) => {
         setStaffOptions(d)
         setSelectedOption(0)
       })
-    fetch('http://localhost:3000/employees?search=&skip=0&take=1000')
+    fetch(`${API_BASE_URL}/employees?search=&skip=0&take=1000`)
       .then((r) => r.json())
       .then((d) => setEmployees(d))
   }, [selectedTemplate])
 
   const createClient = async () => {
-    const res = await fetch('http://localhost:3000/clients', {
+    const res = await fetch(`${API_BASE_URL}/clients`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(newClient),
@@ -136,7 +137,7 @@ export default function CreateAppointmentModal({ onClose, onCreated }: Props) {
       price: parseFloat(templateForm.price),
       notes: templateForm.notes || undefined,
     }
-    const res = await fetch('http://localhost:3000/appointment-templates', {
+    const res = await fetch(`${API_BASE_URL}/appointment-templates`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
@@ -162,7 +163,7 @@ export default function CreateAppointmentModal({ onClose, onCreated }: Props) {
 
   const createAppointment = async () => {
     if (!selectedClient || !selectedTemplate) return
-    const res = await fetch('http://localhost:3000/appointments', {
+    const res = await fetch(`${API_BASE_URL}/appointments`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({

--- a/client/src/Admin/pages/Calendar/index.tsx
+++ b/client/src/Admin/pages/Calendar/index.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { API_BASE_URL } from '../../../api'
 import MonthSelector from './components/MonthSelector'
 import WeekSelector from './components/WeekSelector'
 import DayTimeline from './components/DayTimeline'
@@ -29,7 +30,7 @@ export default function Calendar() {
   useEffect(() => {
     const year = selected.getFullYear()
     const month = selected.getMonth() + 1
-    fetch(`http://localhost:3000/month-info?year=${year}&month=${month}`)
+    fetch(`${API_BASE_URL}/month-info?year=${year}&month=${month}`)
       .then((r) => r.json())
       .then((data) => setMonthInfo(data))
       .catch(() => setMonthInfo(null))
@@ -37,7 +38,7 @@ export default function Calendar() {
 
   useEffect(() => {
     const dateStr = selected.toISOString().slice(0, 10)
-    fetch(`http://localhost:3000/appointments?date=${dateStr}`)
+    fetch(`${API_BASE_URL}/appointments?date=${dateStr}`)
       .then((r) => r.json())
       .then((d) => setAppointments(d))
       .catch(() => setAppointments([]))
@@ -95,7 +96,7 @@ export default function Calendar() {
           onClose={() => setShowCreate(false)}
           onCreated={() => {
             const dateStr = selected.toISOString().slice(0, 10)
-            fetch(`http://localhost:3000/appointments?date=${dateStr}`)
+            fetch(`${API_BASE_URL}/appointments?date=${dateStr}`)
               .then((r) => r.json())
               .then((d) => setAppointments(d))
           }}

--- a/client/src/Admin/pages/Clients/components/ClientForm.tsx
+++ b/client/src/Admin/pages/Clients/components/ClientForm.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { Client } from './types'
+import { API_BASE_URL } from '../../../../api'
 
 export default function ClientForm() {
   const { id } = useParams()
@@ -10,7 +11,7 @@ export default function ClientForm() {
 
   useEffect(() => {
     if (!isNew) {
-      fetch(`http://localhost:3000/clients/${id}`)
+      fetch(`${API_BASE_URL}/clients/${id}`)
         .then((r) => r.json())
         .then((d) => setData(d))
     }
@@ -30,7 +31,7 @@ export default function ClientForm() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     const payload = { name: data.name, number: data.number, notes: data.notes }
-    const res = await fetch(`http://localhost:3000/clients${isNew ? '' : '/' + id}`, {
+    const res = await fetch(`${API_BASE_URL}/clients${isNew ? '' : '/' + id}`, {
       method: isNew ? 'POST' : 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),

--- a/client/src/Admin/pages/Clients/components/ClientList.tsx
+++ b/client/src/Admin/pages/Clients/components/ClientList.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { Client } from './types'
+import { API_BASE_URL } from '../../../../api'
 
 export default function ClientList() {
   const [items, setItems] = useState<Client[]>([])
@@ -20,7 +21,7 @@ export default function ClientList() {
   }, [page, search])
 
   function load() {
-    fetch(`http://localhost:3000/clients?search=${encodeURIComponent(search)}&skip=${page * 20}&take=20`)
+    fetch(`${API_BASE_URL}/clients?search=${encodeURIComponent(search)}&skip=${page * 20}&take=20`)
       .then((r) => r.json())
       .then((data: Client[]) => {
         setItems((prev) => {

--- a/client/src/Admin/pages/Employees/components/EmployeeForm.tsx
+++ b/client/src/Admin/pages/Employees/components/EmployeeForm.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { Employee } from './types'
+import { API_BASE_URL } from '../../../../api'
 
 export default function EmployeeForm() {
   const { id } = useParams()
@@ -15,7 +16,7 @@ export default function EmployeeForm() {
 
   useEffect(() => {
     if (!isNew) {
-      fetch(`http://localhost:3000/employees/${id}`)
+      fetch(`${API_BASE_URL}/employees/${id}`)
         .then((r) => r.json())
         .then((d) => setData({ experienced: false, ...d }))
     }
@@ -46,7 +47,7 @@ export default function EmployeeForm() {
       notes: data.notes,
       experienced: data.experienced,
     }
-    const res = await fetch(`http://localhost:3000/employees${isNew ? '' : '/' + id}` ,{
+    const res = await fetch(`${API_BASE_URL}/employees${isNew ? '' : '/' + id}` ,{
       method: isNew ? 'POST' : 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),

--- a/client/src/Admin/pages/Employees/components/EmployeeList.tsx
+++ b/client/src/Admin/pages/Employees/components/EmployeeList.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { Employee } from './types'
+import { API_BASE_URL } from '../../../../api'
 
 interface EmployeeListProps {}
 
@@ -22,7 +23,7 @@ export default function EmployeeList(_: EmployeeListProps) {
   }, [page, search])
 
   function load() {
-    fetch(`http://localhost:3000/employees?search=${encodeURIComponent(search)}&skip=${page * 20}&take=20`)
+    fetch(`${API_BASE_URL}/employees?search=${encodeURIComponent(search)}&skip=${page * 20}&take=20`)
       .then((r) => r.json())
       .then((data: Employee[]) => {
         setItems((prev) => {

--- a/client/src/Landing/components/Login.tsx
+++ b/client/src/Landing/components/Login.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react'
 import { useGoogleLogin, CodeResponse } from '@react-oauth/google'
+import { API_BASE_URL } from '../../api'
 
 type Role = 'admin' | 'user'
 
@@ -21,7 +22,7 @@ export default function Login({ onLogin }: LoginProps) {
       const code = searchParams.get('code')
       if (!code) return
 
-      const response = await fetch('http://localhost:3000/login', {
+      const response = await fetch(`${API_BASE_URL}/login`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ code })
@@ -50,7 +51,7 @@ export default function Login({ onLogin }: LoginProps) {
     redirect_uri: me,
     flow: 'auth-code',
     onSuccess: async (res: CodeResponse) => {
-      const response = await fetch('http://localhost:3000/login', {
+      const response = await fetch(`${API_BASE_URL}/login`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ code: res.code })

--- a/client/src/Landing/components/LoginCallBack.tsx
+++ b/client/src/Landing/components/LoginCallBack.tsx
@@ -1,6 +1,7 @@
 // src/pages/LoginCallback.tsx
 import { useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { API_BASE_URL } from '../../api'
 
 export default function LoginCallback() {
   const navigate = useNavigate()
@@ -17,7 +18,7 @@ export default function LoginCallback() {
 
     const login = async () => {
       try {
-        const response = await fetch('http://localhost:3000/login', {
+        const response = await fetch(`${API_BASE_URL}/login`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ token: credential }),

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -1,0 +1,1 @@
+export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3000';


### PR DESCRIPTION
## Summary
- support configurable API base URL
- update all client fetches to use the new base URL
- document VITE_API_BASE_URL
- configure ESLint for TypeScript

## Testing
- `npm run lint` *(fails: 14 errors, 9 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6875e2bf11b4832da462ed3d865cb9b1