### PR TITLE
Improve API fetch error handling

### DIFF
--- a/client/src/Admin/pages/Calendar/components/CreateAppointmentModal.tsx
+++ b/client/src/Admin/pages/Calendar/components/CreateAppointmentModal.tsx
@@ -73,7 +73,9 @@ export default function CreateAppointmentModal({ onClose, onCreated }: Props) {
       `${API_BASE_URL}/clients?search=${encodeURIComponent(
         clientSearch
       )}&skip=0&take=20`
-    ).then((d) => setClients(d))
+    )
+      .then((d) => setClients(d))
+      .catch((err) => console.error(err))
   }, [clientSearch])
 
   // Load templates when client selected
@@ -85,6 +87,7 @@ export default function CreateAppointmentModal({ onClose, onCreated }: Props) {
     }
     fetchJson(`${API_BASE_URL}/appointment-templates?clientId=${selectedClient.id}`)
       .then((d) => setTemplates(d))
+      .catch((err) => console.error(err))
   }, [selectedClient])
 
   // Load staff options when template selected
@@ -100,8 +103,10 @@ export default function CreateAppointmentModal({ onClose, onCreated }: Props) {
         setStaffOptions(d)
         setSelectedOption(0)
       })
+      .catch((err) => console.error(err))
     fetchJson(`${API_BASE_URL}/employees?search=&skip=0&take=1000`)
       .then((d) => setEmployees(d))
+      .catch((err) => console.error(err))
   }, [selectedTemplate])
 
   const createClient = async () => {

--- a/client/src/Admin/pages/Clients/components/ClientForm.tsx
+++ b/client/src/Admin/pages/Clients/components/ClientForm.tsx
@@ -13,6 +13,7 @@ export default function ClientForm() {
     if (!isNew) {
       fetchJson(`${API_BASE_URL}/clients/${id}`)
         .then((d) => setData(d))
+        .catch((err) => console.error(err))
     }
   }, [id, isNew])
 

--- a/client/src/Admin/pages/Clients/components/ClientList.tsx
+++ b/client/src/Admin/pages/Clients/components/ClientList.tsx
@@ -35,6 +35,10 @@ export default function ClientList() {
         })
         if (data.length < 20) setHasMore(false)
       })
+      .catch((err) => {
+        console.error(err)
+        setHasMore(false)
+      })
   }
 
   useEffect(() => {

--- a/client/src/Admin/pages/Employees/components/EmployeeForm.tsx
+++ b/client/src/Admin/pages/Employees/components/EmployeeForm.tsx
@@ -18,6 +18,7 @@ export default function EmployeeForm() {
     if (!isNew) {
       fetchJson(`${API_BASE_URL}/employees/${id}`)
         .then((d) => setData({ experienced: false, ...d }))
+        .catch((err) => console.error(err))
     }
   }, [id, isNew])
 

--- a/client/src/Admin/pages/Employees/components/EmployeeList.tsx
+++ b/client/src/Admin/pages/Employees/components/EmployeeList.tsx
@@ -37,6 +37,10 @@ export default function EmployeeList(_: EmployeeListProps) {
         })
         if (data.length < 20) setHasMore(false)
       })
+      .catch((err) => {
+        console.error(err)
+        setHasMore(false)
+      })
   }
 
   useEffect(() => {

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -8,10 +8,19 @@ export async function fetchJson(
 ): Promise<any> {
   const response = await fetch(input, init);
   const text = await response.text();
+  const contentType = response.headers.get('content-type') || '';
+  if (!response.ok) {
+    console.error('Request failed', response.status, text);
+    throw new Error(text || `Request failed with status ${response.status}`);
+  }
+  if (!contentType.includes('application/json')) {
+    console.error('Expected JSON but received:', text);
+    throw new Error('Invalid JSON response');
+  }
   try {
     return JSON.parse(text);
   } catch (err) {
-    console.error('Expected JSON but received:', text);
+    console.error('Failed to parse JSON:', text);
     throw err;
   }
 }


### PR DESCRIPTION
## Summary
- add response checks in `fetchJson`
- ensure fetch errors don't crash lists and forms

## Testing
- `npm run lint` *(fails: Cannot find package 'typescript-eslint')*
- `npm run build` in `server`


------
https://chatgpt.com/codex/tasks/task_e_6875ffb0d070832da9856a303c5fd893