### PR TITLE
Enable optional HTTPS for dev

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -5,3 +5,22 @@ This server uses Express with Prisma for database access. Run `npm install` and 
 The database connection string is configured via `.env` and a `docker-compose.yml` file is provided to start a local PostgreSQL instance.
 
 To enable Google authentication set `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_REDIRECT_URI` and `ADMIN_EMAILS` in your `.env` file. Emails listed in `ADMIN_EMAILS` (comma separated) will be treated as admins when logging in.
+
+## Local HTTPS
+
+The server can also run over HTTPS in development. Generate a self-signed
+certificate and point the server to the key and certificate files using the
+environment variables `SSL_KEY_PATH` and `SSL_CERT_PATH`.
+
+```bash
+# generate certificate valid for your local IP or hostname
+openssl req -x509 -newkey rsa:2048 -nodes \
+  -keyout localhost.key -out localhost.crt -days 365 \
+  -subj "/CN=localhost"
+
+# start the server
+SSL_KEY_PATH=./localhost.key SSL_CERT_PATH=./localhost.crt npm run dev
+```
+
+When these variables are set the server will start an HTTPS listener so you can
+access the API from a secure frontend using your local IP and port.

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1,6 +1,9 @@
 import express, { Request, Response, NextFunction } from 'express'
 import cors from 'cors'
 import dotenv from 'dotenv'
+import fs from 'fs'
+import https from 'https'
+import path from 'path'
 import { PrismaClient } from '@prisma/client'
 import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library'
 import { OAuth2Client } from 'google-auth-library'
@@ -454,6 +457,17 @@ app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
   res.status(500).json({ error: 'Internal server error' })
 })
 
-app.listen(port, () => {
-  console.log(`Server listening on port ${port}`)
-})
+const keyPath = process.env.SSL_KEY_PATH
+const certPath = process.env.SSL_CERT_PATH
+
+if (keyPath && certPath) {
+  const key = fs.readFileSync(path.resolve(keyPath))
+  const cert = fs.readFileSync(path.resolve(certPath))
+  https.createServer({ key, cert }, app).listen(port, () => {
+    console.log(`HTTPS server listening on port ${port}`)
+  })
+} else {
+  app.listen(port, () => {
+    console.log(`Server listening on port ${port}`)
+  })
+}


### PR DESCRIPTION
## Summary
- add https support controlled via SSL env vars
- document self-signed certificate setup

## Testing
- `npm run build`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687602adfb4c832da4c7e141aaec3c5d