### PR TITLE
feat: add ngrok flag to dev server

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -6,5 +6,6 @@ This project was bootstrapped with [Vite](https://vitejs.dev/) and includes `tai
 
 - `npm install` – install dependencies
 - `npm run dev` – start the development server
+- `npm run dev -ngrok` – start dev server and add the `ngrok-skip-browser-warning` header to all API requests
 
 The app starts with a login page where you can sign in with Google. To enable Google sign-in provide `VITE_GOOGLE_CLIENT_ID` in an `.env` file. API requests are sent to `VITE_API_BASE_URL`, which defaults to `http://localhost:3000`.

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -2,11 +2,18 @@ export const API_BASE_URL =
   import.meta.env.VITE_API_BASE_URL ||
   `${window.location.protocol}//${window.location.hostname}:3000`;
 
+const skipNgrokWarning =
+  import.meta.env.VITE_NGROK === 'true' || import.meta.env.VITE_NGROK === '1';
+
 export async function fetchJson(
   input: RequestInfo | URL,
-  init?: RequestInit
+  init: RequestInit = {}
 ): Promise<any> {
-  const response = await fetch(input, init);
+  const headers = new Headers(init.headers);
+  if (skipNgrokWarning) {
+    headers.set('ngrok-skip-browser-warning', '1');
+  }
+  const response = await fetch(input, { ...init, headers });
   const text = await response.text();
   const contentType = response.headers.get('content-type') || '';
   if (!response.ok) {

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -2,11 +2,17 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
-export default defineConfig({
-  plugins: [react()],
-  server: {
-    host: '0.0.0.0', // Allow external access
-    port: 5173,
-    allowedHosts: ['91e6f6a38b02.ngrok-free.app'],
-  },
+export default defineConfig(() => {
+  const isNgrok = process.argv.includes('--ngrok') || process.argv.includes('-ngrok')
+  if (isNgrok) {
+    process.env.VITE_NGROK = 'true'
+  }
+  return {
+    plugins: [react()],
+    server: {
+      host: '0.0.0.0', // Allow external access
+      port: 5173,
+      allowedHosts: ['91e6f6a38b02.ngrok-free.app'],
+    },
+  }
 })


### PR DESCRIPTION
## Summary
- add `-ngrok` command flag to vite config
- send `ngrok-skip-browser-warning` header from API helper when flag used
- document ngrok dev option

## Testing
- `npm run lint` *(fails: missing dependencies and lint errors)*
- `npm test` in `server` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68760c37ac80832db8f2401930b50d7b