### PR TITLE
Fix admin dashboard navigation redirect

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { BrowserRouter, Routes, Route, Navigate, useNavigate } from 'react-router-dom'
+import { BrowserRouter, Routes, Route, Navigate, useNavigate, useLocation } from 'react-router-dom'
 import Login from './Landing/components/Login'
 import Dashboard from './Landing/Dashboard'
 
@@ -24,12 +24,13 @@ interface RoutesProps {
 
 function AppRoutes({ role, onLogin }: RoutesProps) {
   const navigate = useNavigate()
+  const location = useLocation()
 
   useEffect(() => {
-    if (role) {
+    if (role && location.pathname === '/') {
       navigate('/dashboard', { replace: true })
     }
-  }, [role, navigate])
+  }, [role, navigate, location.pathname])
 
   return (
     <Routes>


### PR DESCRIPTION
## Summary
- fix navigation redirect in admin dashboard by checking location before redirecting

## Testing
- `npm run lint` *(fails: Cannot find package 'typescript-eslint' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68761117a0ac832d929a5d4a15173303