### PR TITLE
Improve appointment modal state and timeline layout

### DIFF
--- a/client/src/Admin/pages/Calendar/components/CreateAppointmentModal.tsx
+++ b/client/src/Admin/pages/Calendar/components/CreateAppointmentModal.tsx
@@ -89,6 +89,50 @@ export default function CreateAppointmentModal({ onClose, onCreated }: Props) {
   const [recurringOption, setRecurringOption] = useState<RecurringOption>('Weekly')
   const [recurringMonths, setRecurringMonths] = useState('')
 
+  const resetCarpet = () => {
+    setCarpetEnabled(false)
+    setShowCarpetModal(false)
+    setCarpetRooms('')
+    setCarpetEmployees([])
+    setCarpetRate(null)
+  }
+
+  const resetTemplateRelated = () => {
+    setSelectedTemplate(null)
+    setShowNewTemplate(false)
+    setTemplateForm({
+      templateName: '',
+      type: 'STANDARD',
+      size: '',
+      address: '',
+      price: '',
+      notes: '',
+    })
+    setDate('')
+    setTime('')
+    setStaffOptions([])
+    setSelectedOption(0)
+    setEmployees([])
+    setSelectedEmployees([])
+    setShowTeamModal(false)
+    setEmployeeSearch('')
+    setPayRate(null)
+    resetCarpet()
+    setRecurringEnabled(false)
+    setShowRecurringModal(false)
+    setRecurringOption('Weekly')
+    setRecurringMonths('')
+  }
+
+  const resetAll = () => {
+    setSelectedClient(null)
+    setClientSearch('')
+    setShowNewClient(false)
+    setNewClient({ name: '', number: '', notes: '' })
+    setTemplates([])
+    resetTemplateRelated()
+  }
+
   // Load clients when search changes
   useEffect(() => {
     fetchJson(
@@ -178,6 +222,7 @@ export default function CreateAppointmentModal({ onClose, onCreated }: Props) {
     if (res.ok) {
       const c = await res.json()
       setSelectedClient(c)
+      resetTemplateRelated()
       setShowNewClient(false)
       setClientSearch('')
     } else {
@@ -205,6 +250,7 @@ export default function CreateAppointmentModal({ onClose, onCreated }: Props) {
     if (res.ok) {
       const t = await res.json()
       setTemplates((p) => [...p, t])
+      resetTemplateRelated()
       setSelectedTemplate(t.id)
       setShowNewTemplate(false)
     } else {
@@ -263,7 +309,7 @@ export default function CreateAppointmentModal({ onClose, onCreated }: Props) {
               <div className="font-medium">Client: {selectedClient.name}</div>
               <button
                 className="text-sm text-blue-500"
-                onClick={() => setSelectedClient(null)}
+                onClick={resetAll}
               >
                 change
               </button>
@@ -324,7 +370,10 @@ export default function CreateAppointmentModal({ onClose, onCreated }: Props) {
                 <li
                   key={c.id}
                   className="p-1 hover:bg-gray-100 cursor-pointer"
-                  onClick={() => setSelectedClient(c)}
+                  onClick={() => {
+                    setSelectedClient(c)
+                    resetTemplateRelated()
+                  }}
                 >
                   <div className="font-medium">{c.name}</div>
                   <div className="text-sm text-gray-600">{c.number}</div>
@@ -343,7 +392,7 @@ export default function CreateAppointmentModal({ onClose, onCreated }: Props) {
                   <div className="font-medium">
                     Template: {templates.find((t) => t.id === selectedTemplate)?.templateName}
                   </div>
-                  <button className="text-sm text-blue-500" onClick={() => setSelectedTemplate(null)}>
+                  <button className="text-sm text-blue-500" onClick={resetTemplateRelated}>
                     change
                   </button>
                 </div>
@@ -431,7 +480,10 @@ export default function CreateAppointmentModal({ onClose, onCreated }: Props) {
                   <select
                     className="flex-1 border p-1 rounded"
                     value={selectedTemplate ?? ''}
-                    onChange={(e) => setSelectedTemplate(Number(e.target.value))}
+                    onChange={(e) => {
+                      resetTemplateRelated()
+                      setSelectedTemplate(Number(e.target.value))
+                    }}
                   >
                     <option value="">Select template</option>
                     {templates.map((t) => (
@@ -630,6 +682,7 @@ export default function CreateAppointmentModal({ onClose, onCreated }: Props) {
                 onClick={() => {
                   setSelectedOption(idx)
                   setSelectedEmployees([])
+                  resetCarpet()
                 }}
               >
                 {o.sem} SEM / {o.com} COM - {o.hours}h

--- a/client/src/Admin/pages/Calendar/components/DayTimeline.tsx
+++ b/client/src/Admin/pages/Calendar/components/DayTimeline.tsx
@@ -135,16 +135,34 @@ export default function DayTimeline({
         </div>
       ))}
 
-      {appointments.map((a) => {
-        const [h, m] = a.time.split(':').map((n) => parseInt(n, 10))
+      {Object.entries(
+        appointments.reduce<Record<string, Appointment[]>>((acc, appt) => {
+          acc[appt.time] = acc[appt.time] ? [...acc[appt.time], appt] : [appt]
+          return acc
+        }, {})
+      ).map(([time, group]) => {
+        const [h, m] = time.split(':').map((n) => parseInt(n, 10))
         const top = h * 84 + (m / 60) * 84
         return (
           <div
-            key={a.id}
-            className="absolute left-16 right-2 h-8 bg-blue-200 border border-blue-400 rounded px-1 text-xs overflow-hidden"
-            style={{ top }}
+            key={time}
+            className="absolute flex gap-1"
+            style={{
+              top,
+              left: dividerPx,
+              width: `calc((100% - ${dividerPx}px) * 0.7)`,
+              padding: '2px',
+            }}
           >
-            {a.type}
+            {group.map((a, idx) => (
+              <div
+                key={a.id ?? idx}
+                className="flex-1 bg-blue-200 border border-blue-400 rounded px-1 text-xs overflow-hidden"
+                style={{ height: (a.hours || 1) * 84 }}
+              >
+                {a.type}
+              </div>
+            ))}
           </div>
         )
       })}

--- a/client/src/Admin/pages/Calendar/types.ts
+++ b/client/src/Admin/pages/Calendar/types.ts
@@ -19,4 +19,5 @@ export interface Appointment {
   size?: string
   price?: number
   notes?: string
+  hours?: number
 }


### PR DESCRIPTION
## Summary
- reset appointment modal fields when client or template changes
- clear carpet options when selecting a different team
- display appointments with duration and handle overlaps in DayTimeline
- support optional `hours` field in appointment types

## Testing
- `npm run lint` *(fails: Cannot find package 'typescript-eslint')*

------
https://chatgpt.com/codex/tasks/task_e_68762d62f534832d818d7da5020307e8