### PR TITLE
Update appointment durations

### DIFF
--- a/client/src/Admin/pages/Calendar/components/CreateAppointmentModal.tsx
+++ b/client/src/Admin/pages/Calendar/components/CreateAppointmentModal.tsx
@@ -282,6 +282,7 @@ export default function CreateAppointmentModal({ onClose, onCreated }: Props) {
         templateId: selectedTemplate,
         date,
         time,
+        hours: staffOptions[selectedOption]?.hours,
         employeeIds: selectedEmployees,
       }),
     })

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -44,6 +44,7 @@ model Appointment {
   address         String
   cityStateZip    String?
   size            String?
+  hours           Int?
   price           Float?
   paid            Boolean         @default(false)
   paymentMethod   PaymentMethod

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -435,11 +435,12 @@ app.get('/appointments', async (req: Request, res: Response) => {
 
 app.post('/appointments', async (req: Request, res: Response) => {
   try {
-    const { clientId, templateId, date, time, employeeIds } = req.body as {
+    const { clientId, templateId, date, time, hours, employeeIds } = req.body as {
       clientId?: number
       templateId?: number
       date?: string
       time?: string
+      hours?: number
       employeeIds?: number[]
     }
     if (!clientId || !templateId || !date || !time) {
@@ -460,6 +461,7 @@ app.post('/appointments', async (req: Request, res: Response) => {
         address: template.address,
         cityStateZip: template.cityStateZip,
         size: template.size,
+        hours: hours ?? null,
         price: template.price,
         paymentMethod: 'CASH',
         lineage: 'single',


### PR DESCRIPTION
## Summary
- add `hours` column to the appointment schema
- persist hours when creating appointments on the server
- send hours from the client when creating an appointment

## Testing
- `npm run build` in `client`
- `npm run build` in `server`


------
https://chatgpt.com/codex/tasks/task_e_68774b441344832d8e2aed445e972325