### PR TITLE
Fix stacking of overlapping appointments

### DIFF
--- a/client/src/Admin/pages/Calendar/components/DayTimeline.tsx
+++ b/client/src/Admin/pages/Calendar/components/DayTimeline.tsx
@@ -145,25 +145,33 @@ export default function DayTimeline({
           acc[appt.time] = acc[appt.time] ? [...acc[appt.time], appt] : [appt]
           return acc
         }, {})
-      ).map(([time, group]) => {
+      )
+        .sort(([t1], [t2]) => t1.localeCompare(t2))
+        .map(([time, group]) => {
         const [h, m] = time.split(':').map((n) => parseInt(n, 10))
         const top = h * 84 + (m / 60) * 84
+        const sorted = group
+          .slice()
+          .sort((a, b) =>
+            new Date(a.createdAt ?? '').getTime() -
+            new Date(b.createdAt ?? '').getTime()
+          )
         return (
           <div
             key={time}
-            className="absolute flex gap-1"
+            className="absolute flex flex-row gap-1 overflow-x-auto flex-nowrap"
             style={{
               top,
               left: dividerPx,
-              width: `calc((100% - ${dividerPx}px) * 0.7)`,
+              width: `calc(100% - ${dividerPx}px)`,
               padding: '2px',
               zIndex: 10,
             }}
           >
-            {group.map((a, idx) => (
+            {sorted.map((a, idx) => (
               <div
                 key={a.id ?? idx}
-                className="flex-1 bg-blue-200 border border-blue-400 rounded px-1 text-xs overflow-hidden cursor-pointer"
+                className="flex-shrink-0 min-w-full bg-blue-200 border border-blue-400 rounded px-1 text-xs overflow-hidden cursor-pointer"
                 style={{ height: (a.hours || 1) * 84 - 2 }}
                 onClick={() => setSelected(a)}
               >

--- a/client/src/Admin/pages/Calendar/types.ts
+++ b/client/src/Admin/pages/Calendar/types.ts
@@ -20,4 +20,5 @@ export interface Appointment {
   price?: number
   notes?: string
   hours?: number
+  createdAt?: string
 }


### PR DESCRIPTION
## Summary
- keep appointment createdAt on the client
- sort overlapping appointments by the created date
- make overlapping appointments horizontal and scrollable
- ensure stacking container spans full width

## Testing
- `npm run lint` *(fails: 17 errors, 11 warnings)*
- `npm run build` in `client`
- `npm run build` in `server`


------
https://chatgpt.com/codex/tasks/task_e_68774e2960f4832d8c253de92b85a24d