### PR TITLE
Improve appointment layout and seeding

### DIFF
--- a/server/prisma/seed.ts
+++ b/server/prisma/seed.ts
@@ -10,18 +10,73 @@ async function main() {
     }
   })
 
-  await prisma.client.createMany({
-    data: [
-      { name: 'John Doe', number: '5551111111' },
-      { name: 'Jane Smith', number: '5552222222' }
-    ]
+  const john = await prisma.client.create({
+    data: { name: 'John Doe', number: '5551111111' }
+  })
+  const jane = await prisma.client.create({
+    data: { name: 'Jane Smith', number: '5552222222' }
   })
 
-  await prisma.employee.createMany({
-    data: [
-      { name: 'Emp One', number: '5553333333', experienced: true },
-      { name: 'Emp Two', number: '5554444444', experienced: false }
-    ]
+  const empOne = await prisma.employee.create({
+    data: { name: 'Emp One', number: '5553333333', experienced: true }
+  })
+  const empTwo = await prisma.employee.create({
+    data: { name: 'Emp Two', number: '5554444444', experienced: false }
+  })
+
+  const temp1 = await prisma.appointmentTemplate.create({
+    data: {
+      templateName: 'John Standard',
+      type: 'STANDARD',
+      size: '1500-2000',
+      address: '123 Main St',
+      price: 120,
+      clientId: john.id
+    }
+  })
+  const temp2 = await prisma.appointmentTemplate.create({
+    data: {
+      templateName: 'Jane Deep',
+      type: 'DEEP',
+      size: '1500-2000',
+      address: '456 Oak Ave',
+      price: 200,
+      clientId: jane.id
+    }
+  })
+
+  await prisma.appointment.create({
+    data: {
+      clientId: john.id,
+      date: new Date(),
+      time: '10:00',
+      type: temp1.type,
+      address: temp1.address,
+      size: temp1.size,
+      hours: 4,
+      price: temp1.price,
+      paymentMethod: 'CASH',
+      lineage: 'single',
+      notes: 'Seed appointment',
+      employees: { connect: { id: empOne.id } }
+    }
+  })
+
+  await prisma.appointment.create({
+    data: {
+      clientId: john.id,
+      date: new Date(),
+      time: '11:00',
+      type: temp1.type,
+      address: temp1.address,
+      size: temp1.size,
+      hours: 4,
+      price: temp1.price,
+      paymentMethod: 'CASH',
+      lineage: 'single',
+      notes: 'Seed overlap',
+      employees: { connect: { id: empTwo.id } }
+    }
   })
 }
 


### PR DESCRIPTION
## Summary
- seed database with clients, employees, templates and sample appointments
- support overlapping appointments in the day timeline

## Testing
- `npm test` in `server` *(fails: no test specified)*
- `npm test` in `client` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687755704e50832da71854d12180effe