### PR TITLE
Update calendar layout and timeline behavior

### DIFF
--- a/client/src/Admin/pages/Calendar/components/DayTimeline.tsx
+++ b/client/src/Admin/pages/Calendar/components/DayTimeline.tsx
@@ -5,9 +5,10 @@ interface DayProps {
   appointments: Appointment[]
   nowOffset: number | null
   scrollRef?: Ref<HTMLDivElement>
+  animating: boolean
 }
 
-function Day({ appointments, nowOffset, scrollRef }: DayProps) {
+function Day({ appointments, nowOffset, scrollRef, animating }: DayProps) {
   const [selected, setSelected] = useState<Appointment | null>(null)
 
   // 4rem + 0.5rem in px (assuming 16px base font-size)
@@ -51,11 +52,20 @@ function Day({ appointments, nowOffset, scrollRef }: DayProps) {
     layout.push(e)
   }
 
-  containerWidth = `calc(${dividerPx}px + ${maxLane} * (40vw + ${LANE_GAP}px))`
-  const rightEdge = `calc(${dividerPx}px + ${maxLane} * (40vw + ${LANE_GAP}px))`
+  containerWidth =
+    layout.length === 0
+      ? '100%'
+      : `calc(${dividerPx}px + ${maxLane} * (40vw + ${LANE_GAP}px))`
+  const rightEdge =
+    layout.length === 0
+      ? '100%'
+      : `calc(${dividerPx}px + ${maxLane} * (40vw + ${LANE_GAP}px))`
 
   return (
-    <div ref={scrollRef} className="flex-1 overflow-x-auto overflow-y-auto relative">
+    <div
+      ref={scrollRef}
+      className={`flex-1 relative ${animating ? 'overflow-hidden' : 'overflow-x-auto overflow-y-auto'}`}
+    >
       <div className="relative divide-y" style={{ width: containerWidth }}>
         {/* divider line */}
         <div
@@ -66,7 +76,7 @@ function Day({ appointments, nowOffset, scrollRef }: DayProps) {
         {/* right edge marker */}
         <div
           className="absolute top-0 bottom-0 w-px bg-gray-300 pointer-events-none"
-          style={{ left: rightEdge }}
+          style={layout.length === 0 ? { right: 0 } : { left: rightEdge }}
         />
 
         {/* “now” indicator */}
@@ -241,9 +251,14 @@ export default function DayTimeline({
       onTouchEnd={handleTouchEnd}
     >
       <div className="flex w-[300%]" style={style}>
-        <Day appointments={prevAppointments} nowOffset={null} />
-        <Day appointments={appointments} nowOffset={nowOffset} scrollRef={currentDayRef} />
-        <Day appointments={nextAppointments} nowOffset={null} />
+        <Day appointments={prevAppointments} nowOffset={null} animating={animating} />
+        <Day
+          appointments={appointments}
+          nowOffset={nowOffset}
+          scrollRef={currentDayRef}
+          animating={animating}
+        />
+        <Day appointments={nextAppointments} nowOffset={null} animating={animating} />
       </div>
     </div>
   )

--- a/client/src/Admin/pages/Calendar/index.tsx
+++ b/client/src/Admin/pages/Calendar/index.tsx
@@ -70,23 +70,23 @@ export default function Calendar() {
 
   return (
     <div className="flex flex-col h-full">
-      <MonthSelector
-        selected={selected}
-        setSelected={setSelected}
-        show={showMonth}
-        setShow={setShowMonth}
-        monthInfo={monthInfo}
-        prevMonth={prevMonth}
-        nextMonth={nextMonth}
-      />
-      <WeekSelector
-        days={days}
-        selected={selected}
-        setSelected={setSelected}
-        showMonth={showMonth}
-        prevWeek={prevWeek}
-        nextWeek={nextWeek}
-      />
+      <div className="sticky top-0 z-10 bg-white">
+        <MonthSelector
+          selected={selected}
+          setSelected={setSelected}
+          show={showMonth}
+          setShow={setShowMonth}
+          monthInfo={monthInfo}
+        />
+        <WeekSelector
+          days={days}
+          selected={selected}
+          setSelected={setSelected}
+          showMonth={showMonth}
+          prevWeek={prevWeek}
+          nextWeek={nextWeek}
+        />
+      </div>
       <DayTimeline
         nowOffset={nowOffset}
         prevDay={prevDay}


### PR DESCRIPTION
## Summary
- make month and week selectors sticky so they stay on screen
- allow day timelines to fill the full width when there are no events
- stop timelines from scrolling while paging between days

## Testing
- `npx tsc --noEmit` *(fails: Property 'env' does not exist on type 'ImportMeta')*
- `npm run lint` *(fails: found 21 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6877756e2708832d85156d8ef9f859cd