### PR TITLE
Show now indicator while paging

### DIFF
--- a/client/src/Admin/pages/Calendar/components/DayTimeline.tsx
+++ b/client/src/Admin/pages/Calendar/components/DayTimeline.tsx
@@ -253,14 +253,22 @@ export default function DayTimeline({
       onTouchEnd={handleTouchEnd}
     >
       <div className="flex w-[300%]" style={style}>
-        <Day appointments={prevAppointments} nowOffset={null} animating={animating} />
+        <Day
+          appointments={prevAppointments}
+          nowOffset={nowOffset}
+          animating={animating}
+        />
         <Day
           appointments={appointments}
           nowOffset={nowOffset}
           scrollRef={currentDayRef}
           animating={animating}
         />
-        <Day appointments={nextAppointments} nowOffset={null} animating={animating} />
+        <Day
+          appointments={nextAppointments}
+          nowOffset={nowOffset}
+          animating={animating}
+        />
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- show the "now" marker on adjacent days during swipe

## Testing
- `npm run lint` *(fails: no-unused-vars, no-undef, etc.)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6877849e4774832d9764f051b38b16da