### PR TITLE
Add admin selection for appointments

### DIFF
--- a/client/src/Admin/pages/Calendar/components/CreateAppointmentModal.tsx
+++ b/client/src/Admin/pages/Calendar/components/CreateAppointmentModal.tsx
@@ -55,6 +55,9 @@ export default function CreateAppointmentModal({ onClose, onCreated }: Props) {
   const [date, setDate] = useState('')
   const [time, setTime] = useState('')
 
+  const [admins, setAdmins] = useState<{ id: number; name: string | null; email: string }[]>([])
+  const [adminId, setAdminId] = useState<number | ''>('')
+
   // staff options and employee selection
   const [staffOptions, setStaffOptions] = useState<{ sem: number; com: number; hours: number }[]>([])
   const [selectedOption, setSelectedOption] = useState<number>(0)
@@ -133,7 +136,15 @@ export default function CreateAppointmentModal({ onClose, onCreated }: Props) {
     setNewClient({ name: '', number: '', notes: '' })
     setTemplates([])
     resetTemplateRelated()
+    setAdminId('')
   }
+
+  // Load admins on mount
+  useEffect(() => {
+    fetchJson(`${API_BASE_URL}/admins`)
+      .then((d) => setAdmins(d))
+      .catch((err) => console.error(err))
+  }, [])
 
   // Load clients when search changes
   useEffect(() => {
@@ -316,6 +327,7 @@ export default function CreateAppointmentModal({ onClose, onCreated }: Props) {
         time,
         hours: staffOptions[selectedOption]?.hours,
         employeeIds: selectedEmployees,
+        adminId: adminId || undefined,
       }),
     })
     if (res.ok) {
@@ -539,6 +551,27 @@ export default function CreateAppointmentModal({ onClose, onCreated }: Props) {
           </div>
         )}
 
+        {/* Admin selection */}
+        {selectedTemplate && (
+          <div>
+            <h4 className="font-light">
+              Admin <span className="text-red-500">*</span>
+            </h4>
+            <select
+              className="w-full border p-2 rounded text-base"
+              value={adminId}
+              onChange={(e) => setAdminId(Number(e.target.value))}
+            >
+              <option value="">Select admin</option>
+              {admins.map((a) => (
+                <option key={a.id} value={a.id}>
+                  {a.name || a.email}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
+
         {/* Team selection */}
         {selectedTemplate && staffOptions.length > 0 && (
           <div className="space-y-1">
@@ -697,7 +730,7 @@ export default function CreateAppointmentModal({ onClose, onCreated }: Props) {
         <div className="text-right">
           <button
             className="bg-blue-500 text-white px-6 py-2 rounded disabled:opacity-50"
-            disabled={!selectedTemplate || !date || !time || !isValidSelection() || !isValidCarpet()}
+            disabled={!selectedTemplate || !date || !time || !isValidSelection() || !isValidCarpet() || !adminId}
             onClick={createAppointment}
           >
             Create

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -3,12 +3,14 @@ import { BrowserRouter, Routes, Route, Navigate, useNavigate, useLocation } from
 import Login from './Landing/components/Login'
 import Dashboard from './Landing/Dashboard'
 
-type Role = 'admin' | 'user'
+type Role = 'ADMIN' | 'OWNER' | 'EMPLOYEE'
 
 export default function App() {
   const [role, setRole] = useState<Role | null>(() => {
     const stored = localStorage.getItem('role')
-    return stored === 'admin' || stored === 'user' ? (stored as Role) : null
+    return stored === 'ADMIN' || stored === 'OWNER' || stored === 'EMPLOYEE'
+      ? (stored as Role)
+      : null
   })
   return (
     <BrowserRouter>

--- a/client/src/Landing/Dashboard.tsx
+++ b/client/src/Landing/Dashboard.tsx
@@ -1,12 +1,12 @@
 import AdminDashboard from '../Admin/AdminDashboard'
 import UserDashboard from '../User/UserDashboard'
 
-type Role = 'admin' | 'user'
+type Role = 'ADMIN' | 'OWNER' | 'EMPLOYEE'
 
 interface DashboardProps {
   role: Role
 }
 
 export default function Dashboard({ role }: DashboardProps) {
-  return role === 'admin' ? <AdminDashboard /> : <UserDashboard />
+  return role === 'EMPLOYEE' ? <UserDashboard /> : <AdminDashboard />
 }

--- a/client/src/Landing/components/Login.tsx
+++ b/client/src/Landing/components/Login.tsx
@@ -2,7 +2,7 @@ import { useEffect } from 'react'
 import { useGoogleLogin, CodeResponse } from '@react-oauth/google'
 import { API_BASE_URL } from '../../api'
 
-type Role = 'admin' | 'user'
+type Role = 'ADMIN' | 'OWNER' | 'EMPLOYEE'
 
 interface LoginProps {
   onLogin: (role: Role) => void
@@ -12,7 +12,7 @@ export default function Login({ onLogin }: LoginProps) {
   console.log("This iwndow: " + window.location.origin)
   useEffect(() => {
     const stored = localStorage.getItem('role')
-    if (stored === 'admin' || stored === 'user') {
+    if (stored === 'ADMIN' || stored === 'OWNER' || stored === 'EMPLOYEE') {
       onLogin(stored as Role)
       return
     }

--- a/client/src/Landing/components/LoginCallBack.tsx
+++ b/client/src/Landing/components/LoginCallBack.tsx
@@ -25,7 +25,7 @@ export default function LoginCallback() {
         })
 
         const data = await response.json()
-        if (data.role === 'admin' || data.role === 'user') {
+        if (data.role === 'ADMIN' || data.role === 'OWNER' || data.role === 'EMPLOYEE') {
           localStorage.setItem('role', data.role)
           navigate('/dashboard')
         } else {

--- a/server/prisma/migrations/20250921000000_add_admin_role/migration.sql
+++ b/server/prisma/migrations/20250921000000_add_admin_role/migration.sql
@@ -1,0 +1,11 @@
+-- AlterEnum
+CREATE TYPE "Role" AS ENUM ('EMPLOYEE','ADMIN','OWNER');
+
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "role" "Role" NOT NULL DEFAULT 'EMPLOYEE';
+
+-- AlterTable
+ALTER TABLE "Appointment" ADD COLUMN     "adminId" INTEGER NOT NULL DEFAULT 1;
+
+-- AddForeignKey
+ALTER TABLE "Appointment" ADD CONSTRAINT "Appointment_adminId_fkey" FOREIGN KEY ("adminId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -12,6 +12,9 @@ model User {
   id    Int    @id @default(autoincrement())
   email String @unique
   name  String?
+  role  Role   @default(EMPLOYEE)
+
+  appointments Appointment[] @relation("AdminAppointments")
 }
 
 model Client {
@@ -38,6 +41,8 @@ model Appointment {
   id              Int             @id @default(autoincrement())
   date            DateTime
   time            String
+  adminId        Int
+  admin          User            @relation("AdminAppointments", fields: [adminId], references: [id])
   clientId        Int
   client          Client          @relation(fields: [clientId], references: [id])
   type            AppointmentType
@@ -112,4 +117,10 @@ enum AppointmentType {
   STANDARD
   DEEP
   MOVE_IN_OUT
+}
+
+enum Role {
+  EMPLOYEE
+  ADMIN
+  OWNER
 }


### PR DESCRIPTION
## Summary
- store role in `User` table
- track admin for each appointment
- add `/admins` endpoint for frontend selector
- include admin dropdown in appointment modal
- adapt login flow and role handling for EMPLOYEE/ADMIN/OWNER
- add migration for new schema

## Testing
- `npm run build` in `server`
- `npm run build` in `client`

------
https://chatgpt.com/codex/tasks/task_e_687792187048832db0ac57001eeecfb7