### PR TITLE
Implement payment tracking and color-coded appointments

### DIFF
--- a/client/src/Admin/pages/Calendar/components/CreateAppointmentModal.tsx
+++ b/client/src/Admin/pages/Calendar/components/CreateAppointmentModal.tsx
@@ -57,6 +57,8 @@ export default function CreateAppointmentModal({ onClose, onCreated }: Props) {
 
   const [admins, setAdmins] = useState<{ id: number; name: string | null; email: string }[]>([])
   const [adminId, setAdminId] = useState<number | ''>('')
+  const [paid, setPaid] = useState(false)
+  const [tip, setTip] = useState('')
 
   // staff options and employee selection
   const [staffOptions, setStaffOptions] = useState<{ sem: number; com: number; hours: number }[]>([])
@@ -127,6 +129,8 @@ export default function CreateAppointmentModal({ onClose, onCreated }: Props) {
     setShowRecurringModal(false)
     setRecurringOption('Weekly')
     setRecurringMonths('')
+    setPaid(false)
+    setTip('')
   }
 
   const resetAll = () => {
@@ -328,6 +332,8 @@ export default function CreateAppointmentModal({ onClose, onCreated }: Props) {
         hours: staffOptions[selectedOption]?.hours,
         employeeIds: selectedEmployees,
         adminId: adminId || undefined,
+        paid,
+        tip: paid ? parseFloat(tip) || 0 : 0,
       }),
     })
     if (res.ok) {
@@ -726,6 +732,29 @@ export default function CreateAppointmentModal({ onClose, onCreated }: Props) {
                 </option>
               ))}
             </select>
+          </div>
+        )}
+
+        {/* Payment details */}
+        {selectedTemplate && (
+          <div className="flex items-center gap-2">
+            <label className="flex items-center gap-1">
+              <input
+                type="checkbox"
+                checked={paid}
+                onChange={(e) => setPaid(e.target.checked)}
+              />
+              Paid
+            </label>
+            {paid && (
+              <input
+                type="number"
+                className="border p-2 rounded text-base flex-1"
+                placeholder="Tip"
+                value={tip}
+                onChange={(e) => setTip(e.target.value)}
+              />
+            )}
           </div>
         )}
 

--- a/client/src/Admin/pages/Calendar/components/DayTimeline.tsx
+++ b/client/src/Admin/pages/Calendar/components/DayTimeline.tsx
@@ -93,10 +93,27 @@ function Day({ appointments, nowOffset, scrollRef, animating }: DayProps) {
           const top = (l.start / 60) * 84
           const height = ((l.end - l.start) / 60) * 84 - 2
           const leftStyle = `calc(${dividerPx}px + ${l.lane} * (40vw + ${LANE_GAP}px))`
+          const apptDate = new Date(l.appt.date)
+          const [sh, sm] = l.appt.time.split(':').map((n) => parseInt(n, 10))
+          const startDate = new Date(
+            apptDate.getFullYear(),
+            apptDate.getMonth(),
+            apptDate.getDate(),
+            sh,
+            sm,
+          )
+          const endDate = new Date(startDate.getTime() + (l.appt.hours ?? 1) * 60 * 60 * 1000)
+          const now = new Date()
+          let bg = 'bg-yellow-200 border-yellow-400'
+          if (l.appt.paid) {
+            bg = 'bg-green-200 border-green-400'
+          } else if (endDate < now) {
+            bg = 'bg-red-200 border-red-400'
+          }
           return (
             <div
               key={l.appt.id ?? idx}
-              className="absolute bg-blue-200 border border-blue-400 rounded text-xs overflow-hidden cursor-pointer"
+              className={`absolute border rounded text-xs overflow-hidden cursor-pointer ${bg}`}
               style={{ top, left: leftStyle, width: apptWidth, height, zIndex: 10 }}
               onClick={() => setSelected(l.appt)}
             >

--- a/client/src/Admin/pages/Calendar/types.ts
+++ b/client/src/Admin/pages/Calendar/types.ts
@@ -20,5 +20,7 @@ export interface Appointment {
   price?: number
   notes?: string
   hours?: number
+  paid?: boolean
+  tip?: number
   createdAt?: string
 }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -442,7 +442,17 @@ app.get('/appointments', async (req: Request, res: Response) => {
 
 app.post('/appointments', async (req: Request, res: Response) => {
   try {
-    const { clientId, templateId, date, time, hours, employeeIds, adminId } = req.body as {
+    const {
+      clientId,
+      templateId,
+      date,
+      time,
+      hours,
+      employeeIds,
+      adminId,
+      paid,
+      tip,
+    } = req.body as {
       clientId?: number
       templateId?: number
       date?: string
@@ -450,6 +460,8 @@ app.post('/appointments', async (req: Request, res: Response) => {
       hours?: number
       employeeIds?: number[]
       adminId?: number
+      paid?: boolean
+      tip?: number
     }
     if (!clientId || !templateId || !date || !time || !adminId) {
       return res.status(400).json({ error: 'Missing fields' })
@@ -471,6 +483,8 @@ app.post('/appointments', async (req: Request, res: Response) => {
         size: template.size,
         hours: hours ?? null,
         price: template.price,
+        paid: paid ?? false,
+        tip: tip ?? 0,
         paymentMethod: 'CASH',
         lineage: 'single',
         notes: template.cityStateZip || undefined,


### PR DESCRIPTION
## Summary
- capture paid state and tip in appointment forms
- color appointment blocks based on payment status and time
- handle paid/tip fields on backend

## Testing
- `npm run build` in `server`
- `npm test` in `server` *(fails: Error: no test specified)*
- `npm run lint` in `server` *(fails: Missing script: "lint")*
- `npm run build` in `client`
- `npm test` in `client` *(fails: Missing script: "test")*
- `npm run lint` in `client` *(fails with lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6877991d1aec832d89a161a96417a314