### PR TITLE
Add payment method field and fix timeline color

### DIFF
--- a/client/src/Admin/pages/Calendar/components/CreateAppointmentModal.tsx
+++ b/client/src/Admin/pages/Calendar/components/CreateAppointmentModal.tsx
@@ -59,6 +59,8 @@ export default function CreateAppointmentModal({ onClose, onCreated }: Props) {
   const [adminId, setAdminId] = useState<number | ''>('')
   const [paid, setPaid] = useState(false)
   const [tip, setTip] = useState('')
+  const [paymentMethod, setPaymentMethod] = useState('')
+  const [otherPayment, setOtherPayment] = useState('')
 
   // staff options and employee selection
   const [staffOptions, setStaffOptions] = useState<{ sem: number; com: number; hours: number }[]>([])
@@ -131,6 +133,8 @@ export default function CreateAppointmentModal({ onClose, onCreated }: Props) {
     setRecurringMonths('')
     setPaid(false)
     setTip('')
+    setPaymentMethod('')
+    setOtherPayment('')
   }
 
   const resetAll = () => {
@@ -333,6 +337,9 @@ export default function CreateAppointmentModal({ onClose, onCreated }: Props) {
         employeeIds: selectedEmployees,
         adminId: adminId || undefined,
         paid,
+        paymentMethod: paid ? (paymentMethod || 'CASH') : 'CASH',
+        paymentMethodNote:
+          paid && paymentMethod === 'OTHER' && otherPayment ? otherPayment : undefined,
         tip: paid ? parseFloat(tip) || 0 : 0,
       }),
     })
@@ -737,23 +744,49 @@ export default function CreateAppointmentModal({ onClose, onCreated }: Props) {
 
         {/* Payment details */}
         {selectedTemplate && (
-          <div className="flex items-center gap-2">
-            <label className="flex items-center gap-1">
-              <input
-                type="checkbox"
-                checked={paid}
-                onChange={(e) => setPaid(e.target.checked)}
-              />
-              Paid
-            </label>
+          <div className="flex flex-col gap-2">
+            <div className="flex items-center gap-2">
+              <label className="flex items-center gap-1">
+                <input
+                  type="checkbox"
+                  checked={paid}
+                  onChange={(e) => setPaid(e.target.checked)}
+                />
+                Paid
+              </label>
+              {paid && (
+                <input
+                  type="number"
+                  className="border p-2 rounded text-base flex-1"
+                  placeholder="Tip"
+                  value={tip}
+                  onChange={(e) => setTip(e.target.value)}
+                />
+              )}
+            </div>
             {paid && (
-              <input
-                type="number"
-                className="border p-2 rounded text-base flex-1"
-                placeholder="Tip"
-                value={tip}
-                onChange={(e) => setTip(e.target.value)}
-              />
+              <div className="flex flex-col gap-1">
+                <select
+                  className="w-full border p-2 rounded text-base"
+                  value={paymentMethod}
+                  onChange={(e) => setPaymentMethod(e.target.value)}
+                >
+                  <option value="">Select payment method</option>
+                  <option value="CASH">Cash</option>
+                  <option value="ZELLE">Zelle</option>
+                  <option value="VENMO">Venmo</option>
+                  <option value="PAYPAL">Paypal</option>
+                  <option value="OTHER">Other</option>
+                </select>
+                {paymentMethod === 'OTHER' && (
+                  <input
+                    className="w-full border p-2 rounded text-base"
+                    placeholder="Payment method"
+                    value={otherPayment}
+                    onChange={(e) => setOtherPayment(e.target.value)}
+                  />
+                )}
+              </div>
             )}
           </div>
         )}
@@ -761,7 +794,15 @@ export default function CreateAppointmentModal({ onClose, onCreated }: Props) {
         <div className="text-right">
           <button
             className="bg-blue-500 text-white px-6 py-2 rounded disabled:opacity-50"
-            disabled={!selectedTemplate || !date || !time || !isValidSelection() || !isValidCarpet() || !adminId}
+            disabled={
+              !selectedTemplate ||
+              !date ||
+              !time ||
+              !isValidSelection() ||
+              !isValidCarpet() ||
+              !adminId ||
+              (paid && (!paymentMethod || (paymentMethod === 'OTHER' && !otherPayment)))
+            }
             onClick={createAppointment}
           >
             Create

--- a/client/src/Admin/pages/Calendar/components/DayTimeline.tsx
+++ b/client/src/Admin/pages/Calendar/components/DayTimeline.tsx
@@ -107,7 +107,7 @@ function Day({ appointments, nowOffset, scrollRef, animating }: DayProps) {
           let bg = 'bg-yellow-200 border-yellow-400'
           if (l.appt.paid) {
             bg = 'bg-green-200 border-green-400'
-          } else if (endDate < now) {
+          } else if (endDate <= now) {
             bg = 'bg-red-200 border-red-400'
           }
           return (

--- a/client/src/Admin/pages/Calendar/index.tsx
+++ b/client/src/Admin/pages/Calendar/index.tsx
@@ -63,9 +63,14 @@ export default function Calendar() {
   const nextDay = () => setSelected((d) => addDays(d, 1))
 
   useEffect(() => {
-    const now = new Date()
-    const offset = now.getHours() * 84 + (now.getMinutes() / 60) * 84
-    setNowOffset(offset)
+    const update = () => {
+      const now = new Date()
+      const offset = now.getHours() * 84 + (now.getMinutes() / 60) * 84
+      setNowOffset(offset)
+    }
+    update()
+    const id = setInterval(update, 60000)
+    return () => clearInterval(id)
   }, [])
 
   return (

--- a/client/src/Admin/pages/Calendar/types.ts
+++ b/client/src/Admin/pages/Calendar/types.ts
@@ -21,6 +21,7 @@ export interface Appointment {
   notes?: string
   hours?: number
   paid?: boolean
+  paymentMethod?: 'CASH' | 'ZELLE' | 'VENMO' | 'PAYPAL' | 'OTHER' | 'CHECK'
   tip?: number
   createdAt?: string
 }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -451,6 +451,8 @@ app.post('/appointments', async (req: Request, res: Response) => {
       employeeIds,
       adminId,
       paid,
+      paymentMethod,
+      paymentMethodNote,
       tip,
     } = req.body as {
       clientId?: number
@@ -461,6 +463,8 @@ app.post('/appointments', async (req: Request, res: Response) => {
       employeeIds?: number[]
       adminId?: number
       paid?: boolean
+      paymentMethod?: string
+      paymentMethodNote?: string
       tip?: number
     }
     if (!clientId || !templateId || !date || !time || !adminId) {
@@ -485,9 +489,9 @@ app.post('/appointments', async (req: Request, res: Response) => {
         price: template.price,
         paid: paid ?? false,
         tip: tip ?? 0,
-        paymentMethod: 'CASH',
+        paymentMethod: (paymentMethod as any) ?? 'CASH',
+        notes: paymentMethodNote ?? template.cityStateZip || undefined,
         lineage: 'single',
-        notes: template.cityStateZip || undefined,
         admin: { connect: { id: adminId } },
         ...(employeeIds && employeeIds.length
           ? { employees: { connect: employeeIds.map((id) => ({ id })) } }


### PR DESCRIPTION
## Summary
- add payment method selection to appointment creation
- allow specifying custom payment method text
- require payment method when marking appointment as paid
- update server to store chosen payment method
- update timeline color logic and keep current time marker updated

## Testing
- `npm run lint` *(fails: no-unused-vars and other errors)*
- `npm test` in `server` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68779de8cbf8832db1a31b11b910c379