### PR TITLE
Update appointment details modal

### DIFF
--- a/client/src/Admin/pages/Calendar/types.ts
+++ b/client/src/Admin/pages/Calendar/types.ts
@@ -16,6 +16,7 @@ export interface Appointment {
   clientId: number
   type: 'STANDARD' | 'DEEP' | 'MOVE_IN_OUT'
   address: string
+  cityStateZip?: string
   size?: string
   price?: number
   notes?: string
@@ -23,5 +24,8 @@ export interface Appointment {
   paid?: boolean
   paymentMethod?: 'CASH' | 'ZELLE' | 'VENMO' | 'PAYPAL' | 'OTHER' | 'CHECK'
   tip?: number
+  reoccurring?: boolean
+  client?: import('../Clients/components/types').Client
+  employees?: import('../Employees/components/types').Employee[]
   createdAt?: string
 }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -433,6 +433,7 @@ app.get('/appointments', async (req: Request, res: Response) => {
     const appts = await prisma.appointment.findMany({
       where: { date: { gte: date, lt: next } },
       orderBy: { time: 'asc' },
+      include: { client: true, employees: true },
     })
     res.json(appts)
   } catch (e) {
@@ -510,6 +511,30 @@ app.post('/appointments', async (req: Request, res: Response) => {
   } catch (err) {
     console.error('Error creating appointment:', err)
     return res.status(500).json({ error: 'Failed to create appointment' })
+  }
+})
+
+app.put('/appointments/:id', async (req: Request, res: Response) => {
+  const id = parseInt(req.params.id, 10)
+  if (isNaN(id)) return res.status(400).json({ error: 'Invalid id' })
+  try {
+    const { paid, paymentMethod, paymentMethodNote, tip } = req.body as {
+      paid?: boolean
+      paymentMethod?: string
+      paymentMethodNote?: string
+      tip?: number
+    }
+    const data: any = {}
+    if (paid !== undefined) data.paid = paid
+    if (paymentMethod !== undefined) data.paymentMethod = paymentMethod as any
+    if (paymentMethodNote !== undefined) data.notes = paymentMethodNote
+    if (tip !== undefined) data.tip = tip
+
+    const appt = await prisma.appointment.update({ where: { id }, data, include: { client: true, employees: true } })
+    res.json(appt)
+  } catch (e) {
+    console.error('Error updating appointment:', e)
+    res.status(500).json({ error: 'Failed to update appointment' })
   }
 })
 


### PR DESCRIPTION
## Summary
- extend Appointment type with more optional fields
- show client, team, and recurring info in the details modal
- add Save button for updating payment info
- allow scrolling past the modal and open at current viewport position
- refresh appointments when updated or created
- expose PUT `/appointments/:id` and include relations in GET `/appointments`

## Testing
- `npm run build` in `client`
- `npm run build` in `server`
- `npm run lint` *(fails: 'no-unused-vars' and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68782fd8d354832d9cf9a13cfb6d0350