### PR TITLE
Fix appointment modal placement

### DIFF
--- a/client/src/Admin/pages/Calendar/components/DayTimeline.tsx
+++ b/client/src/Admin/pages/Calendar/components/DayTimeline.tsx
@@ -12,7 +12,8 @@ interface DayProps {
 
 function Day({ appointments, nowOffset, scrollRef, animating, onUpdate }: DayProps) {
   const [selected, setSelected] = useState<Appointment | null>(null)
-  const [modalTop, setModalTop] = useState(0)
+  const [offsetTop, setOffsetTop] = useState(0)
+  const [offsetBottom, setOffsetBottom] = useState(0)
   const [showDelete, setShowDelete] = useState(false)
   const [showCancel, setShowCancel] = useState(false)
   const [payRate, setPayRate] = useState<number | null>(null)
@@ -59,6 +60,15 @@ function Day({ appointments, nowOffset, scrollRef, animating, onUpdate }: DayPro
         document.body.style.overflow = original
       }
     }
+  }, [selected])
+
+  // Measure top and bottom offsets when modal opens
+  useEffect(() => {
+    if (!selected) return
+    const topEl = document.querySelector('div.sticky.top-0') as HTMLElement | null
+    const bottomEl = document.querySelector('nav.fixed.bottom-0') as HTMLElement | null
+    setOffsetTop(topEl ? topEl.offsetHeight : 0)
+    setOffsetBottom(bottomEl ? bottomEl.offsetHeight : 0)
   }, [selected])
 
   // calculate pay rates when modal opens
@@ -193,7 +203,6 @@ function Day({ appointments, nowOffset, scrollRef, animating, onUpdate }: DayPro
               className={`absolute border rounded text-xs overflow-hidden cursor-pointer ${bg}`}
               style={{ top, left: leftStyle, width: apptWidth, height, zIndex: 10 }}
               onClick={() => {
-                setModalTop(window.scrollY)
                 setSelected(l.appt)
               }}
             >
@@ -214,12 +223,12 @@ function Day({ appointments, nowOffset, scrollRef, animating, onUpdate }: DayPro
       {/* details modal */}
       {selected && (
         <div
-          className="absolute left-0 right-0 bg-black/50 flex items-center justify-center z-40 p-2"
-          style={{ top: modalTop, height: '100vh' }}
+          className="fixed inset-x-0 bg-black/50 flex items-center justify-center z-40 p-2 overflow-hidden"
+          style={{ top: offsetTop, bottom: offsetBottom }}
           onClick={() => setSelected(null)}
         >
           <div
-            className="bg-white p-4 rounded space-y-2 w-full max-w-md"
+            className="bg-white p-4 rounded space-y-2 w-full max-w-md max-h-full overflow-y-auto"
             onClick={(e) => e.stopPropagation()}
           >
             <div className="flex justify-between items-center">


### PR DESCRIPTION
## Summary
- adjust `DayTimeline` appointment detail modal location
- keep white modal centered without covering top or bottom bars
- enable scrolling inside the modal content

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687a0a569600832db808207fb8fb7ffc