### PR TITLE
Add appointment status with observe flow

### DIFF
--- a/client/src/Admin/pages/Calendar/types.ts
+++ b/client/src/Admin/pages/Calendar/types.ts
@@ -25,6 +25,14 @@ export interface Appointment {
   paymentMethod?: 'CASH' | 'ZELLE' | 'VENMO' | 'PAYPAL' | 'OTHER' | 'CHECK'
   tip?: number
   reoccurring?: boolean
+  status?:
+    | 'APPOINTED'
+    | 'RESCHEDULE_IN'
+    | 'RESCHEDULE_OUT'
+    | 'CANCEL'
+    | 'OBSERVE'
+    | 'REBOOK'
+    | 'REOCCURRING'
   client?: import('../Clients/components/types').Client
   employees?: import('../Employees/components/types').Employee[]
   createdAt?: string

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -55,6 +55,7 @@ model Appointment {
   paymentMethod   PaymentMethod
   tip             Float           @default(0)
   reoccurring     Boolean         @default(false)
+  status          AppointmentStatus @default(APPOINTED)
   lineage         String
   gateCode        String?
   doorCode        String?
@@ -123,4 +124,14 @@ enum Role {
   EMPLOYEE
   ADMIN
   OWNER
+}
+
+enum AppointmentStatus {
+  APPOINTED
+  RESCHEDULE_IN
+  RESCHEDULE_OUT
+  CANCEL
+  OBSERVE
+  REBOOK
+  REOCCURRING
 }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -497,6 +497,7 @@ app.post('/appointments', async (req: Request, res: Response) => {
         tip,
         paymentMethod: paymentMethod as any, // or cast to your enum
         notes: paymentMethodNote || undefined,
+        status: 'APPOINTED',
         lineage: 'single',
         // only include the relation if there are IDs
         ...(employeeIds.length > 0 && {
@@ -518,17 +519,19 @@ app.put('/appointments/:id', async (req: Request, res: Response) => {
   const id = parseInt(req.params.id, 10)
   if (isNaN(id)) return res.status(400).json({ error: 'Invalid id' })
   try {
-    const { paid, paymentMethod, paymentMethodNote, tip } = req.body as {
+    const { paid, paymentMethod, paymentMethodNote, tip, status } = req.body as {
       paid?: boolean
       paymentMethod?: string
       paymentMethodNote?: string
       tip?: number
+      status?: string
     }
     const data: any = {}
     if (paid !== undefined) data.paid = paid
     if (paymentMethod !== undefined) data.paymentMethod = paymentMethod as any
     if (paymentMethodNote !== undefined) data.notes = paymentMethodNote
     if (tip !== undefined) data.tip = tip
+    if (status !== undefined) data.status = status as any
 
     const appt = await prisma.appointment.update({ where: { id }, data, include: { client: true, employees: true } })
     res.json(appt)


### PR DESCRIPTION
## Summary
- add `AppointmentStatus` enum to Prisma schema and a `status` field in `Appointment`
- set default status when creating appointments and allow updating status
- update appointment type definitions for status
- support observe/cancel/reschedule actions in `DayTimeline`
- color appointments based on paid/observe status

## Testing
- `npm run build` in `server`
- `npm run build` in `client`


------
https://chatgpt.com/codex/tasks/task_e_687a19b686cc832da379c1c7ec7dfa0d