### PR TITLE
Close appointment modal on action

### DIFF
--- a/client/src/Admin/pages/Calendar/components/DayTimeline.tsx
+++ b/client/src/Admin/pages/Calendar/components/DayTimeline.tsx
@@ -34,13 +34,16 @@ function Day({ appointments, nowOffset, scrollRef, animating, onUpdate }: DayPro
     if (!selected) return
     const res = await fetch(`${API_BASE_URL}/appointments/${selected.id}`, {
       method: 'PUT',
-      headers: { 'Content-Type': 'application/json', 'ngrok-skip-browser-warning': '1' },
+      headers: {
+        'Content-Type': 'application/json',
+        'ngrok-skip-browser-warning': '1',
+      },
       body: JSON.stringify({ status }),
     })
     if (res.ok) {
       const updated = await res.json()
-      setSelected(updated)
       onUpdate?.(updated)
+      setSelected(null)
     } else {
       alert('Failed to update appointment')
     }
@@ -49,18 +52,22 @@ function Day({ appointments, nowOffset, scrollRef, animating, onUpdate }: DayPro
     if (!selected) return
     const res = await fetch(`${API_BASE_URL}/appointments/${selected.id}`, {
       method: 'PUT',
-      headers: { 'Content-Type': 'application/json', 'ngrok-skip-browser-warning': '1' },
+      headers: {
+        'Content-Type': 'application/json',
+        'ngrok-skip-browser-warning': '1',
+      },
       body: JSON.stringify({
         paid,
         paymentMethod: paid ? (paymentMethod || 'CASH') : 'CASH',
-        paymentMethodNote: paid && paymentMethod === 'OTHER' && otherPayment ? otherPayment : undefined,
+        paymentMethodNote:
+          paid && paymentMethod === 'OTHER' && otherPayment ? otherPayment : undefined,
         tip: paid ? parseFloat(tip) || 0 : 0,
       }),
     })
     if (res.ok) {
       const updated = await res.json()
-      setSelected(updated)
       onUpdate?.(updated)
+      setSelected(null)
     } else {
       alert('Failed to update appointment')
     }


### PR DESCRIPTION
## Summary
- close appointment view when saving or updating status

## Testing
- `npm run build` in `client`
- `npm run build` in `server`


------
https://chatgpt.com/codex/tasks/task_e_687a271d5974832db0e5d17435d37037