### PR TITLE
Update modal handling for appointments

### DIFF
--- a/client/src/Admin/pages/Calendar/components/CreateAppointmentModal.tsx
+++ b/client/src/Admin/pages/Calendar/components/CreateAppointmentModal.tsx
@@ -371,8 +371,14 @@ export default function CreateAppointmentModal({ onClose, onCreated, initialClie
 
   return (
     <>
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-20 p-2">
-      <div className="bg-white p-4 sm:p-6 rounded w-full max-w-md max-h-full overflow-y-auto overflow-x-hidden space-y-4">
+    <div
+      className="fixed inset-0 bg-black/50 flex items-center justify-center z-20 p-2"
+      onClick={onClose}
+    >
+      <div
+        className="bg-white p-4 sm:p-6 rounded w-full max-w-md max-h-full overflow-y-auto overflow-x-hidden space-y-4"
+        onClick={(e) => e.stopPropagation()}
+      >
         <div className="flex justify-between items-center">
           <h2 className="text-lg font-semibold">New Appointment</h2>
           <button onClick={onClose}>X</button>

--- a/client/src/Admin/pages/Calendar/components/DayTimeline.tsx
+++ b/client/src/Admin/pages/Calendar/components/DayTimeline.tsx
@@ -373,7 +373,9 @@ function Day({ appointments, nowOffset, scrollRef, animating, onUpdate, onCreate
               <button
                 className="px-4 py-1 bg-purple-500 text-white rounded"
                 onClick={() =>
-                  selected?.status === 'OBSERVE' ? updateStatus('CANCEL') : setShowCancel(true)
+                  selected?.status === 'OBSERVE'
+                    ? updateStatus('CANCEL')
+                    : setShowCancel(true)
                 }
               >
                 Cancel
@@ -388,7 +390,11 @@ function Day({ appointments, nowOffset, scrollRef, animating, onUpdate, onCreate
                   </button>
                   <button
                     className="px-4 py-1 bg-blue-500 text-white rounded"
-                    onClick={() => onCreate?.(selected!, 'RESCHEDULE_NEW')}
+                    onClick={() => {
+                      const appt = selected!
+                      setSelected(null)
+                      onCreate?.(appt, 'RESCHEDULE_NEW')
+                    }}
                   >
                     Reschedule
                   </button>
@@ -412,7 +418,11 @@ function Day({ appointments, nowOffset, scrollRef, animating, onUpdate, onCreate
                     disabled={
                       paid && (!paymentMethod || (paymentMethod === 'OTHER' && !otherPayment))
                     }
-                    onClick={() => onCreate?.(selected!, 'REBOOK')}
+                    onClick={() => {
+                      const appt = selected!
+                      setSelected(null)
+                      onCreate?.(appt, 'REBOOK')
+                    }}
                   >
                     Book Again
                   </button>
@@ -466,7 +476,7 @@ function Day({ appointments, nowOffset, scrollRef, animating, onUpdate, onCreate
                   className="bg-white p-4 rounded space-y-2"
                   onClick={(e) => e.stopPropagation()}
                 >
-                  <div>Cancel changes?</div>
+                  <div>Cancel appointment?</div>
                   <div className="flex justify-end gap-2">
                     <button className="px-4 py-1 border rounded" onClick={() => setShowCancel(false)}>
                       No
@@ -475,7 +485,7 @@ function Day({ appointments, nowOffset, scrollRef, animating, onUpdate, onCreate
                       className="px-4 py-1 bg-purple-500 text-white rounded"
                       onClick={() => {
                         setShowCancel(false)
-                        setSelected(null)
+                        updateStatus('CANCEL')
                       }}
                     >
                       Yes


### PR DESCRIPTION
## Summary
- close `CreateAppointmentModal` when user clicks outside of it
- close appointment block view when choosing Book Again or Reschedule
- confirm cancelling appointment and mark status CANCEL

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687a4f8fbf90832d80265fbd1f411c27