### PR TITLE
Fix sign out state and keep appointment modal open

### DIFF
--- a/client/src/Admin/AdminDashboard.tsx
+++ b/client/src/Admin/AdminDashboard.tsx
@@ -5,10 +5,15 @@ import Clients from './pages/Clients'
 import Employees from './pages/Employees'
 import Financing from './pages/Financing'
 
-export default function AdminDashboard() {
+interface Props {
+  onLogout: () => void
+}
+
+export default function AdminDashboard({ onLogout }: Props) {
   const navigate = useNavigate()
   const signOut = () => {
     localStorage.removeItem('role')
+    onLogout()
     navigate('/')
   }
 

--- a/client/src/Admin/pages/Calendar/index.tsx
+++ b/client/src/Admin/pages/Calendar/index.tsx
@@ -55,8 +55,19 @@ export default function Calendar() {
     clientId?: number
     templateId?: number | null
     status?: Appointment['status']
-  } | null>(null)
-  const [rescheduleOldId, setRescheduleOldId] = useState<number | null>(null)
+  } | null>(() => {
+    const stored = sessionStorage.getItem('createParams')
+    if (stored) {
+      try {
+        return JSON.parse(stored)
+      } catch {}
+    }
+    return null
+  })
+  const [rescheduleOldId, setRescheduleOldId] = useState<number | null>(() => {
+    const stored = sessionStorage.getItem('rescheduleOldId')
+    return stored ? Number(stored) : null
+  })
 
   const handleUpdate = (updated: Appointment) => {
     setAppointments((appts) => {
@@ -79,6 +90,22 @@ export default function Calendar() {
     }
     localStorage.setItem('calendarSelectedDate', JSON.stringify(data))
   }, [selected])
+
+  useEffect(() => {
+    if (createParams) {
+      sessionStorage.setItem('createParams', JSON.stringify(createParams))
+    } else {
+      sessionStorage.removeItem('createParams')
+    }
+  }, [createParams])
+
+  useEffect(() => {
+    if (rescheduleOldId === null) {
+      sessionStorage.removeItem('rescheduleOldId')
+    } else {
+      sessionStorage.setItem('rescheduleOldId', String(rescheduleOldId))
+    }
+  }, [rescheduleOldId])
 
   const refresh = (d = selected) => {
     const fetchDay = (day: Date) =>
@@ -191,7 +218,10 @@ export default function Calendar() {
       </button>
       {createParams && (
         <CreateAppointmentModal
-          onClose={() => setCreateParams(null)}
+          onClose={() => {
+            setCreateParams(null)
+            setRescheduleOldId(null)
+          }}
           onCreated={() => {
             if (rescheduleOldId) {
               markOldReschedule(rescheduleOldId).then(() => setRescheduleOldId(null))

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -14,7 +14,7 @@ export default function App() {
   })
   return (
     <BrowserRouter>
-      <AppRoutes role={role} onLogin={setRole} />
+      <AppRoutes role={role} onLogin={setRole} onLogout={() => setRole(null)} />
     </BrowserRouter>
   )
 }
@@ -22,9 +22,10 @@ export default function App() {
 interface RoutesProps {
   role: Role | null
   onLogin: (role: Role) => void
+  onLogout: () => void
 }
 
-function AppRoutes({ role, onLogin }: RoutesProps) {
+function AppRoutes({ role, onLogin, onLogout }: RoutesProps) {
   const navigate = useNavigate()
   const location = useLocation()
 
@@ -39,7 +40,7 @@ function AppRoutes({ role, onLogin }: RoutesProps) {
       <Route path="/" element={<Login onLogin={onLogin} />} />
       <Route
         path="/dashboard/*"
-        element={role ? <Dashboard role={role} /> : <Navigate to="/" replace />}
+        element={role ? <Dashboard role={role} onLogout={onLogout} /> : <Navigate to="/" replace />}
       />
     </Routes>
   )

--- a/client/src/Landing/Dashboard.tsx
+++ b/client/src/Landing/Dashboard.tsx
@@ -5,8 +5,13 @@ type Role = 'ADMIN' | 'OWNER' | 'EMPLOYEE'
 
 interface DashboardProps {
   role: Role
+  onLogout: () => void
 }
 
-export default function Dashboard({ role }: DashboardProps) {
-  return role === 'EMPLOYEE' ? <UserDashboard /> : <AdminDashboard />
+export default function Dashboard({ role, onLogout }: DashboardProps) {
+  return role === 'EMPLOYEE' ? (
+    <UserDashboard onLogout={onLogout} />
+  ) : (
+    <AdminDashboard onLogout={onLogout} />
+  )
 }

--- a/client/src/User/UserDashboard.tsx
+++ b/client/src/User/UserDashboard.tsx
@@ -1,9 +1,14 @@
 import { useNavigate } from 'react-router-dom'
 
-export default function UserDashboard() {
+interface Props {
+  onLogout: () => void
+}
+
+export default function UserDashboard({ onLogout }: Props) {
   const navigate = useNavigate()
   const signOut = () => {
     localStorage.removeItem('role')
+    onLogout()
     navigate('/')
   }
 


### PR DESCRIPTION
## Summary
- pass `onLogout` callback through router so sign out resets role state
- clear sign out state in dashboards
- store appointment modal state in session storage
- restore modal state on reload and clear when closed

## Testing
- `npm run lint` *(fails: 55 problems)*

------
https://chatgpt.com/codex/tasks/task_e_687a8b48f00c832da2312a265b68415f