### PR TITLE
Fix template selection persistence

### DIFF
--- a/client/src/Admin/pages/Calendar/components/CreateAppointmentModal.tsx
+++ b/client/src/Admin/pages/Calendar/components/CreateAppointmentModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useRef } from 'react'
 import { Client } from '../../Clients/components/types'
 import type { AppointmentTemplate } from '../types'
 import type { Employee } from '../../Employees/components/types'
@@ -243,10 +243,12 @@ export default function CreateAppointmentModal({ onClose, onCreated, initialClie
   }, [clientSearch])
 
   // Load templates when client selected
+  const prevClientRef = useRef<Client | null>(null)
   useEffect(() => {
     if (!selectedClient) {
       setTemplates([])
-      setSelectedTemplate(null)
+      if (prevClientRef.current) setSelectedTemplate(null)
+      prevClientRef.current = selectedClient
       return
     }
     fetchJson(`${API_BASE_URL}/appointment-templates?clientId=${selectedClient.id}`)
@@ -258,6 +260,7 @@ export default function CreateAppointmentModal({ onClose, onCreated, initialClie
         }
       })
       .catch((err) => console.error(err))
+    prevClientRef.current = selectedClient
   }, [selectedClient, initialTemplateId])
 
   // Load staff options when template selected


### PR DESCRIPTION
## Summary
- maintain selected template across refreshes
- fix blank page on the new appointment modal by importing `useRef`

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687aa1c91450832d971949833688b6be