### PR TITLE
Fix template persistence on refresh

### DIFF
--- a/client/src/Admin/pages/Calendar/components/CreateAppointmentModal.tsx
+++ b/client/src/Admin/pages/Calendar/components/CreateAppointmentModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useRef } from 'react'
 import { Client } from '../../Clients/components/types'
 import type { AppointmentTemplate } from '../types'
 import type { Employee } from '../../Employees/components/types'
@@ -105,6 +105,9 @@ export default function CreateAppointmentModal({ onClose, onCreated, initialClie
     onClose()
   }
 
+  const initializedRef = useRef(false)
+  const storedTemplateIdRef = useRef<number | null>(null)
+
   useEffect(() => {
     const stored = sessionStorage.getItem('createAppointmentState')
     if (stored) {
@@ -114,7 +117,10 @@ export default function CreateAppointmentModal({ onClose, onCreated, initialClie
         if (s.selectedClient) setSelectedClient(s.selectedClient)
         if (s.newClient) setNewClient(s.newClient)
         if (typeof s.showNewClient === 'boolean') setShowNewClient(s.showNewClient)
-        if (typeof s.selectedTemplate !== 'undefined') setSelectedTemplate(s.selectedTemplate)
+        if (typeof s.selectedTemplate !== 'undefined') {
+          setSelectedTemplate(s.selectedTemplate)
+          storedTemplateIdRef.current = s.selectedTemplate
+        }
         if (typeof s.showNewTemplate === 'boolean') setShowNewTemplate(s.showNewTemplate)
         if (typeof s.editing === 'boolean') setEditing(s.editing)
         if (s.templateForm) setTemplateForm({ ...templateForm, ...s.templateForm })
@@ -135,9 +141,11 @@ export default function CreateAppointmentModal({ onClose, onCreated, initialClie
         if (s.recurringMonths) setRecurringMonths(s.recurringMonths)
       } catch {}
     }
+    initializedRef.current = true
   }, [])
 
   useEffect(() => {
+    if (!initializedRef.current) return
     const data = {
       clientSearch,
       selectedClient,
@@ -243,21 +251,31 @@ export default function CreateAppointmentModal({ onClose, onCreated, initialClie
   }, [clientSearch])
 
   // Load templates when client selected
+  const prevClientRef = useRef<Client | null>(null)
   useEffect(() => {
     if (!selectedClient) {
       setTemplates([])
-      setSelectedTemplate(null)
+      if (prevClientRef.current) setSelectedTemplate(null)
+      prevClientRef.current = selectedClient
       return
     }
     fetchJson(`${API_BASE_URL}/appointment-templates?clientId=${selectedClient.id}`)
       .then((d) => {
         setTemplates(d)
-        if (initialTemplateId) {
+        const storedId = storedTemplateIdRef.current
+        if (storedId) {
+          const match = d.find((t: any) => t.id === storedId)
+          if (match) {
+            setSelectedTemplate(match.id)
+            storedTemplateIdRef.current = null
+          }
+        } else if (initialTemplateId) {
           const match = d.find((t: any) => t.id === initialTemplateId)
           if (match) setSelectedTemplate(match.id)
         }
       })
       .catch((err) => console.error(err))
+    prevClientRef.current = selectedClient
   }, [selectedClient, initialTemplateId])
 
   // Load staff options when template selected


### PR DESCRIPTION
## Summary
- keep template ID from session storage in a ref
- when loading templates, reselect the persisted template if available

## Testing
- `npm run lint` *(fails: multiple lint errors)*
- `npm test` *(fails: no test script available)*

------
https://chatgpt.com/codex/tasks/task_e_687aa1c91450832d971949833688b6be