### PR TITLE
Fix template selection persistence

### DIFF
--- a/client/src/Admin/pages/Calendar/components/CreateAppointmentModal.tsx
+++ b/client/src/Admin/pages/Calendar/components/CreateAppointmentModal.tsx
@@ -194,6 +194,17 @@ export default function CreateAppointmentModal({ onClose, onCreated, initialClie
     if (selectedTemplate !== null) {
       localStorage.setItem('createAppointmentSelectedTemplateId', String(selectedTemplate))
       console.log('Stored this id:', localStorage.getItem('createAppointmentSelectedTemplateId'))
+    } else {
+      localStorage.removeItem('createAppointmentSelectedTemplateId')
+    }
+
+    const stored = sessionStorage.getItem('createAppointmentState')
+    if (stored) {
+      try {
+        const data = JSON.parse(stored)
+        data.selectedTemplate = selectedTemplate
+        sessionStorage.setItem('createAppointmentState', JSON.stringify(data))
+      } catch {}
     }
   }, [selectedTemplate])
 


### PR DESCRIPTION
## Summary
- ensure selected template updates session storage in CreateAppointmentModal

## Testing
- `npm run build` in `client`
- `npm run build` in `server`
- `npm test` in `server` *(fails: "Error: no test specified")*

------
https://chatgpt.com/codex/tasks/task_e_687abdbc6fc4832d95d90289f000fc8e