### PR TITLE
Move carpet options into appointment template

### DIFF
--- a/client/src/Admin/pages/Calendar/types.ts
+++ b/client/src/Admin/pages/Calendar/types.ts
@@ -7,6 +7,8 @@ export interface AppointmentTemplate {
   price: number
   clientId: number
   cityStateZip?: string // used for notes
+  carpetEnabled?: boolean
+  carpetRooms?: string
 }
 
 export interface Appointment {


### PR DESCRIPTION
## Summary
- store carpet settings on appointment templates
- show carpet checkboxes and room count inside the template form
- display carpet info when a template is selected
- sync carpet state whenever templates change

## Testing
- `npm install` within `client`
- `npm run build` within `client`
- `npm install` within `server`
- `npm run build` within `server`


------
https://chatgpt.com/codex/tasks/task_e_687ac8715b90832d93819bb956426c19