### PR TITLE
Prioritize observe state color

### DIFF
--- a/client/src/Admin/pages/Calendar/components/DayTimeline.tsx
+++ b/client/src/Admin/pages/Calendar/components/DayTimeline.tsx
@@ -235,11 +235,11 @@ function Day({ appointments, nowOffset, scrollRef, animating, onUpdate, onCreate
           if (l.appt.paid) {
             bg = 'bg-green-200 border-green-400'
           }
-          if (l.appt.observe) {
-            bg = 'bg-yellow-200 border-yellow-400'
-          }
           if (l.appt.status === 'CANCEL') {
             bg = 'bg-purple-200 border-purple-400'
+          }
+          if (l.appt.observe) {
+            bg = 'bg-yellow-200 border-yellow-400'
           }
           return (
             <div


### PR DESCRIPTION
## Summary
- reorder color logic in `DayTimeline` so observed appointments appear yellow even if canceled

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` in client *(fails: Missing script)*
- `npm test` in server *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687cdf1e5bac832db537b64c63e15c86