### PR TITLE
Implement editing for recurring appointments

### DIFF
--- a/client/src/Admin/pages/Calendar/components/DayTimeline.tsx
+++ b/client/src/Admin/pages/Calendar/components/DayTimeline.tsx
@@ -37,7 +37,12 @@ function Day({ appointments, nowOffset, scrollRef, animating, onUpdate, onCreate
     observe?: boolean
   }) => {
     if (!selected) return
-    const res = await fetch(`${API_BASE_URL}/appointments/${selected.id}`, {
+    let url = `${API_BASE_URL}/appointments/${selected.id}`
+    if (selected.reoccurring) {
+      const apply = confirm('Apply to all future occurrences?')
+      if (apply) url += '?future=true'
+    }
+    const res = await fetch(url, {
       method: 'PUT',
       headers: {
         'Content-Type': 'application/json',
@@ -53,14 +58,19 @@ function Day({ appointments, nowOffset, scrollRef, animating, onUpdate, onCreate
       alert('Failed to update appointment')
     }
   }
-  const handleSave = async () => {
-    if (!selected) return
-    const res = await fetch(`${API_BASE_URL}/appointments/${selected.id}`, {
-      method: 'PUT',
-      headers: {
-        'Content-Type': 'application/json',
-        'ngrok-skip-browser-warning': '1',
-      },
+const handleSave = async () => {
+  if (!selected) return
+  let url = `${API_BASE_URL}/appointments/${selected.id}`
+  if (selected.reoccurring) {
+    const apply = confirm('Apply to all future occurrences?')
+    if (apply) url += '?future=true'
+  }
+  const res = await fetch(url, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+      'ngrok-skip-browser-warning': '1',
+    },
       body: JSON.stringify({
         paid,
         paymentMethod: paid ? (paymentMethod || 'CASH') : 'CASH',

--- a/client/src/Admin/pages/Calendar/index.tsx
+++ b/client/src/Admin/pages/Calendar/index.tsx
@@ -142,7 +142,8 @@ export default function Calendar() {
 
   const handleEdit = async (appt: Appointment) => {
     sessionStorage.removeItem('createAppointmentState')
-    setDeleteOldId(appt.id!)
+    setDeleteOldId(null)
+    setRescheduleOldId(null)
     try {
       const templates = await fetchJson(
         `${API_BASE_URL}/appointment-templates?clientId=${appt.clientId}`

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -8,6 +8,7 @@ import { PrismaClient } from '@prisma/client'
 import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library'
 import { OAuth2Client } from 'google-auth-library'
 import axios from 'axios'
+import crypto from 'crypto'
 import { staffOptionsData } from './data/staffOptions'
 dotenv.config()
 
@@ -444,6 +445,112 @@ app.get('/appointments', async (req: Request, res: Response) => {
   }
 })
 
+app.get('/appointments/lineage/:lineage', async (req: Request, res: Response) => {
+  const { lineage } = req.params
+  try {
+    const appts = await prisma.appointment.findMany({
+      where: { lineage },
+      orderBy: { date: 'asc' },
+      include: { client: true, employees: true },
+    })
+    res.json(appts)
+  } catch {
+    res.status(500).json({ error: 'Failed to fetch lineage appointments' })
+  }
+})
+
+app.post('/appointments/recurring', async (req: Request, res: Response) => {
+  try {
+    const {
+      clientId,
+      templateId,
+      date,
+      time,
+      hours,
+      employeeIds = [],
+      adminId,
+      paid = false,
+      paymentMethod = 'CASH',
+      paymentMethodNote,
+      tip = 0,
+      count = 1,
+      frequency,
+    } = req.body as {
+      clientId?: number
+      templateId?: number
+      date?: string
+      time?: string
+      hours?: number
+      employeeIds?: number[]
+      adminId?: number
+      paid?: boolean
+      paymentMethod?: string
+      paymentMethodNote?: string
+      tip?: number
+      count?: number
+      frequency?: string
+    }
+
+    if (!clientId || !templateId || !date || !time || !adminId || !frequency) {
+      return res.status(400).json({ error: 'Missing required fields' })
+    }
+
+    const template = await prisma.appointmentTemplate.findUnique({
+      where: { id: templateId },
+    })
+    if (!template) {
+      return res.status(400).json({ error: 'Invalid templateId' })
+    }
+
+    const lineage = crypto.randomUUID()
+    const first = new Date(date)
+    const created: any[] = []
+    for (let i = 0; i < count; i++) {
+      const d = new Date(first)
+      if (frequency === 'WEEKLY') d.setDate(d.getDate() + i * 7)
+      else if (frequency === 'BIWEEKLY') d.setDate(d.getDate() + i * 14)
+      else if (frequency === 'EVERY3') d.setDate(d.getDate() + i * 21)
+      else if (frequency === 'MONTHLY') d.setMonth(d.getMonth() + i)
+      else {
+        const m = parseInt(String(req.body.months || 1), 10)
+        d.setMonth(d.getMonth() + i * (isNaN(m) ? 1 : m))
+      }
+      const appt = await prisma.appointment.create({
+        data: {
+          clientId,
+          adminId,
+          date: d,
+          time,
+          type: template.type,
+          address: template.address,
+          cityStateZip: template.cityStateZip,
+          size: template.size,
+          hours: hours ?? null,
+          price: template.price,
+          paid,
+          tip,
+          paymentMethod: paymentMethod as any,
+          notes: paymentMethodNote || undefined,
+          status: 'REOCCURRING',
+          lineage,
+          reoccurring: true,
+          ...(employeeIds.length > 0 && {
+            employees: {
+              connect: employeeIds.map((id) => ({ id })),
+            },
+          }),
+        },
+      })
+      created.push(appt)
+    }
+
+    res.json(created)
+  } catch (err) {
+    console.error('Error creating recurring appointments:', err)
+    res.status(500).json({ error: 'Failed to create recurring appointments' })
+  }
+})
+
 app.post('/appointments', async (req: Request, res: Response) => {
   try {
     const {
@@ -525,6 +632,13 @@ app.put('/appointments/:id', async (req: Request, res: Response) => {
   if (isNaN(id)) return res.status(400).json({ error: 'Invalid id' })
   try {
     const {
+      clientId,
+      templateId,
+      date,
+      time,
+      hours,
+      employeeIds,
+      adminId,
       paid,
       paymentMethod,
       paymentMethodNote,
@@ -532,6 +646,13 @@ app.put('/appointments/:id', async (req: Request, res: Response) => {
       status,
       observe,
     } = req.body as {
+      clientId?: number
+      templateId?: number
+      date?: string
+      time?: string
+      hours?: number
+      employeeIds?: number[]
+      adminId?: number
       paid?: boolean
       paymentMethod?: string
       paymentMethodNote?: string
@@ -540,15 +661,52 @@ app.put('/appointments/:id', async (req: Request, res: Response) => {
       observe?: boolean
     }
     const data: any = {}
+    if (clientId !== undefined) data.clientId = clientId
+    if (templateId !== undefined) {
+      const template = await prisma.appointmentTemplate.findUnique({
+        where: { id: templateId },
+      })
+      if (!template) return res.status(400).json({ error: 'Invalid templateId' })
+      data.type = template.type
+      data.address = template.address
+      data.cityStateZip = template.cityStateZip ?? undefined
+      data.size = template.size ?? undefined
+      data.price = template.price
+    }
+    if (date !== undefined) data.date = new Date(date)
+    if (time !== undefined) data.time = time
+    if (hours !== undefined) data.hours = hours
+    if (adminId !== undefined) data.adminId = adminId
     if (paid !== undefined) data.paid = paid
     if (paymentMethod !== undefined) data.paymentMethod = paymentMethod as any
     if (paymentMethodNote !== undefined) data.notes = paymentMethodNote
     if (tip !== undefined) data.tip = tip
     if (status !== undefined) data.status = status as any
     if (observe !== undefined) data.observe = observe
-
-    const appt = await prisma.appointment.update({ where: { id }, data, include: { client: true, employees: true } })
-    res.json(appt)
+    if (employeeIds) {
+      data.employees = { set: employeeIds.map((id) => ({ id })) }
+    }
+    const future = req.query.future === 'true'
+    const current = await prisma.appointment.findUnique({ where: { id } })
+    if (!current) return res.status(404).json({ error: 'Not found' })
+    if (future && current.lineage !== 'single') {
+      await prisma.appointment.updateMany({
+        where: { lineage: current.lineage, date: { gte: current.date } },
+        data,
+      })
+      const appts = await prisma.appointment.findMany({
+        where: { lineage: current.lineage, date: { gte: current.date } },
+        include: { client: true, employees: true },
+      })
+      res.json(appts)
+    } else {
+      const appt = await prisma.appointment.update({
+        where: { id },
+        data,
+        include: { client: true, employees: true },
+      })
+      res.json(appt)
+    }
   } catch (e) {
     console.error('Error updating appointment:', e)
     res.status(500).json({ error: 'Failed to update appointment' })


### PR DESCRIPTION
## Summary
- extend update endpoint to handle more fields and bulk updates
- allow editing appointments via CreateAppointmentModal
- show modal without deleting old appointment when editing

## Testing
- `npm run build` in `server`
- `npm install && npm run build` in `client`


------
https://chatgpt.com/codex/tasks/task_e_687cf5a582f8832da6bdea5138ee2782