### PR TITLE
Add Financing subpages

### DIFF
--- a/client/src/Admin/AdminDashboard.tsx
+++ b/client/src/Admin/AdminDashboard.tsx
@@ -35,7 +35,7 @@ export default function AdminDashboard({ onLogout }: Props) {
           <Route path="calendar" element={<Calendar />} />
           <Route path="clients/*" element={<Clients />} />
           <Route path="employees/*" element={<Employees />} />
-          <Route path="financing" element={<Financing />} />
+          <Route path="financing/*" element={<Financing />} />
         </Routes>
       </main>
     </div>

--- a/client/src/Admin/pages/Financing/Invoice.tsx
+++ b/client/src/Admin/pages/Financing/Invoice.tsx
@@ -1,0 +1,11 @@
+import { Link } from 'react-router-dom'
+
+export default function Invoice() {
+  return (
+    <div className="p-4">
+      <Link to=".." className="text-blue-500 text-sm">&larr; Back</Link>
+      <h2 className="text-xl font-semibold mb-2">Invoice</h2>
+      {/* TODO: add invoice table */}
+    </div>
+  )
+}

--- a/client/src/Admin/pages/Financing/Payroll.tsx
+++ b/client/src/Admin/pages/Financing/Payroll.tsx
@@ -1,0 +1,11 @@
+import { Link } from 'react-router-dom'
+
+export default function Payroll() {
+  return (
+    <div className="p-4">
+      <Link to=".." className="text-blue-500 text-sm">&larr; Back</Link>
+      <h2 className="text-xl font-semibold mb-2">Payroll</h2>
+      {/* TODO: add payroll table */}
+    </div>
+  )
+}

--- a/client/src/Admin/pages/Financing/Revenue.tsx
+++ b/client/src/Admin/pages/Financing/Revenue.tsx
@@ -1,0 +1,11 @@
+import { Link } from 'react-router-dom'
+
+export default function Revenue() {
+  return (
+    <div className="p-4">
+      <Link to=".." className="text-blue-500 text-sm">&larr; Back</Link>
+      <h2 className="text-xl font-semibold mb-2">Revenue</h2>
+      {/* TODO: add revenue table */}
+    </div>
+  )
+}

--- a/client/src/Admin/pages/Financing/index.tsx
+++ b/client/src/Admin/pages/Financing/index.tsx
@@ -1,9 +1,28 @@
-import React from 'react'
+import { Routes, Route, Link } from 'react-router-dom'
+import Payroll from './Payroll'
+import Invoice from './Invoice'
+import Revenue from './Revenue'
 
 export default function Financing() {
   return (
+    <Routes>
+      <Route index element={<FinancingHome />} />
+      <Route path="payroll" element={<Payroll />} />
+      <Route path="invoice" element={<Invoice />} />
+      <Route path="revenue" element={<Revenue />} />
+    </Routes>
+  )
+}
+
+function FinancingHome() {
+  return (
     <div className="p-4">
-      <h2 className="text-xl font-semibold">Financing</h2>
+      <h2 className="text-xl font-semibold mb-4">Financing</h2>
+      <div className="grid gap-4 sm:grid-cols-3">
+        <Link to="payroll" className="bg-blue-500 text-white py-3 rounded text-center">Payroll</Link>
+        <Link to="invoice" className="bg-green-500 text-white py-3 rounded text-center">Invoice</Link>
+        <Link to="revenue" className="bg-purple-500 text-white py-3 rounded text-center">Revenue</Link>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- hook up Financing route for nested subpages
- add subpages for Payroll, Invoice and Revenue
- style Financing home with navigation buttons

## Testing
- `npm run lint` *(fails: 54 errors, 15 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_687e22677ff0832daf864c9406ec9856