### PR TITLE
Implement invoice creation and PDF generation

### DIFF
--- a/client/src/Admin/pages/Financing/Invoice.tsx
+++ b/client/src/Admin/pages/Financing/Invoice.tsx
@@ -1,11 +1,43 @@
+import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
+import { API_BASE_URL, fetchJson } from '../../../api'
+import type { Appointment } from '../Calendar/types'
+import CreateInvoiceModal from './components/CreateInvoiceModal'
 
 export default function Invoice() {
+  const [date, setDate] = useState(() => new Date().toISOString().slice(0, 10))
+  const [appointments, setAppointments] = useState<Appointment[]>([])
+  const [selected, setSelected] = useState<Appointment | null>(null)
+
+  useEffect(() => {
+    fetchJson(`${API_BASE_URL}/appointments?date=${date}`)
+      .then((d) => setAppointments(d))
+      .catch(() => setAppointments([]))
+  }, [date])
+
   return (
-    <div className="p-4">
+    <div className="p-4 pb-16">
       <Link to=".." className="text-blue-500 text-sm">&larr; Back</Link>
       <h2 className="text-xl font-semibold mb-2">Invoice</h2>
-      {/* TODO: add invoice table */}
+      <div className="mb-4">
+        <input type="date" className="border p-2 rounded" value={date} onChange={(e) => setDate(e.target.value)} />
+      </div>
+      <div className="space-y-3">
+        {appointments.map((a) => (
+          <div
+            key={a.id}
+            className="bg-white shadow rounded p-3 cursor-pointer"
+            onClick={() => setSelected(a)}
+          >
+            <div className="font-medium">{a.client?.name}</div>
+            <div className="text-sm">{a.client?.number}</div>
+            <div className="text-sm">{a.address}</div>
+          </div>
+        ))}
+      </div>
+      {selected && (
+        <CreateInvoiceModal appointment={selected} onClose={() => setSelected(null)} />
+      )}
     </div>
   )
 }

--- a/client/src/Admin/pages/Financing/components/CreateInvoiceModal.tsx
+++ b/client/src/Admin/pages/Financing/components/CreateInvoiceModal.tsx
@@ -1,0 +1,123 @@
+import { useState } from 'react'
+import type { Appointment } from '../../Calendar/types'
+import { API_BASE_URL } from '../../../api'
+
+interface Props {
+  appointment: Appointment
+  onClose: () => void
+}
+
+export default function CreateInvoiceModal({ appointment, onClose }: Props) {
+  const [clientName, setClientName] = useState(appointment.client?.name || '')
+  const [billedTo, setBilledTo] = useState(appointment.client?.name || '')
+  const [address, setAddress] = useState(appointment.address)
+  const [serviceDate, setServiceDate] = useState(appointment.date.slice(0, 10))
+  const [time, setTime] = useState(appointment.time)
+  const [serviceType, setServiceType] = useState(appointment.type)
+  const [price, setPrice] = useState(String(appointment.price ?? ''))
+  const [carpetPrice, setCarpetPrice] = useState('')
+  const [discount, setDiscount] = useState('')
+  const [taxEnabled, setTaxEnabled] = useState(false)
+  const [taxPercent, setTaxPercent] = useState('')
+
+  const subtotal =
+    (parseFloat(price) || 0) +
+    (parseFloat(carpetPrice) || 0) -
+    (parseFloat(discount) || 0)
+  const total =
+    subtotal + (taxEnabled ? subtotal * ((parseFloat(taxPercent) || 0) / 100) : 0)
+
+  const create = async () => {
+    const payload = {
+      clientName,
+      billedTo,
+      address,
+      serviceDate,
+      serviceTime: time,
+      serviceType,
+      price: parseFloat(price) || 0,
+      carpetPrice: carpetPrice ? parseFloat(carpetPrice) : undefined,
+      discount: discount ? parseFloat(discount) : undefined,
+      taxPercent: taxEnabled ? parseFloat(taxPercent) || 0 : undefined,
+    }
+    const res = await fetch(`${API_BASE_URL}/invoices`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'ngrok-skip-browser-warning': '1' },
+      body: JSON.stringify(payload),
+    })
+    if (res.ok) {
+      const data = await res.json()
+      window.open(`${API_BASE_URL}/invoices/${data.id}/pdf`, '_blank')
+      onClose()
+    } else {
+      alert('Failed to create invoice')
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-2 z-30" onClick={onClose}>
+      <div className="bg-white p-4 rounded w-full max-w-md space-y-3" onClick={(e) => e.stopPropagation()}>
+        <div className="flex justify-between items-center">
+          <h2 className="text-lg font-semibold">Create Invoice</h2>
+          <button onClick={onClose}>X</button>
+        </div>
+        <div>
+          <label className="text-sm">Client Name</label>
+          <input className="w-full border p-2 rounded" value={clientName} onChange={(e) => setClientName(e.target.value)} />
+        </div>
+        <div>
+          <label className="text-sm">Billed To</label>
+          <input className="w-full border p-2 rounded" value={billedTo} onChange={(e) => setBilledTo(e.target.value)} />
+        </div>
+        <div>
+          <label className="text-sm">Address</label>
+          <input className="w-full border p-2 rounded" value={address} onChange={(e) => setAddress(e.target.value)} />
+        </div>
+        <div className="flex gap-2">
+          <div className="flex-1">
+            <label className="text-sm">Date of Service</label>
+            <input type="date" className="w-full border p-2 rounded" value={serviceDate} onChange={(e) => setServiceDate(e.target.value)} />
+          </div>
+          <div className="flex-1">
+            <label className="text-sm">Time</label>
+            <input className="w-full border p-2 rounded" value={time} onChange={(e) => setTime(e.target.value)} />
+          </div>
+        </div>
+        <div className="flex gap-2">
+          <div className="flex-1">
+            <label className="text-sm">Service Type</label>
+            <input className="w-full border p-2 rounded" value={serviceType} onChange={(e) => setServiceType(e.target.value)} />
+          </div>
+          <div className="flex-1">
+            <label className="text-sm">Price</label>
+            <input type="number" className="w-full border p-2 rounded" value={price} onChange={(e) => setPrice(e.target.value)} />
+          </div>
+        </div>
+        <div className="flex gap-2">
+          <div className="flex-1">
+            <label className="text-sm">Carpet (optional)</label>
+            <input type="number" className="w-full border p-2 rounded" value={carpetPrice} onChange={(e) => setCarpetPrice(e.target.value)} />
+          </div>
+        </div>
+        <div>
+          <label className="text-sm">Discount (optional)</label>
+          <input type="number" className="w-full border p-2 rounded" value={discount} onChange={(e) => setDiscount(e.target.value)} />
+        </div>
+        <div>
+          <label className="flex items-center gap-2 text-sm">
+            <input type="checkbox" checked={taxEnabled} onChange={(e) => setTaxEnabled(e.target.checked)} />
+            Tax
+          </label>
+          {taxEnabled && (
+            <input type="number" className="w-full border p-2 rounded mt-1" value={taxPercent} onChange={(e) => setTaxPercent(e.target.value)} placeholder="Percent" />
+          )}
+        </div>
+        <div className="font-medium">Total: ${total.toFixed(2)}</div>
+        <div className="flex justify-end gap-2 pt-2">
+          <button className="px-4 py-1" onClick={onClose}>Cancel</button>
+          <button className="px-4 py-1 bg-blue-500 text-white rounded" onClick={create}>Create</button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -14,7 +14,8 @@
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
-        "google-auth-library": "^10.1.0"
+        "google-auth-library": "^10.1.0",
+        "pdf-lib": "^1.17.1"
       },
       "devDependencies": {
         "@types/cors": "^2.8.19",
@@ -65,6 +66,24 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@pdf-lib/standard-fonts": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/standard-fonts/-/standard-fonts-1.0.0.tgz",
+      "integrity": "sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.6"
+      }
+    },
+    "node_modules/@pdf-lib/upng": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/upng/-/upng-1.0.1.tgz",
+      "integrity": "sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.10"
       }
     },
     "node_modules/@prisma/client": {
@@ -1571,6 +1590,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -1585,6 +1610,18 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "license": "MIT"
+    },
+    "node_modules/pdf-lib": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/pdf-lib/-/pdf-lib-1.17.1.tgz",
+      "integrity": "sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@pdf-lib/standard-fonts": "^1.0.0",
+        "@pdf-lib/upng": "^1.0.1",
+        "pako": "^1.0.11",
+        "tslib": "^1.11.1"
+      }
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -1983,6 +2020,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
     },
     "node_modules/type-is": {
       "version": "1.6.18",

--- a/server/package.json
+++ b/server/package.json
@@ -19,7 +19,8 @@
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
-    "google-auth-library": "^10.1.0"
+    "google-auth-library": "^10.1.0",
+    "pdf-lib": "^1.17.1"
   },
   "devDependencies": {
     "@types/cors": "^2.8.19",


### PR DESCRIPTION
## Summary
- add pdf-lib dependency for the server
- automatically create an `Invoice` table if it doesn't exist
- expose new `/invoices` API for creating invoices and `/invoices/:id/pdf` to fetch a PDF
- add invoice list page that shows appointments for a day
- implement `CreateInvoiceModal` for entering invoice data

## Testing
- `npm --prefix server run build`
- `npm --prefix client run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e26b0ac98832d814997805bed104d