### PR TITLE
Improve invoice PDF and favicon

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/png" href="/logo.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>React Dashboard</title>
   </head>

--- a/client/src/Admin/pages/Financing/components/CreateInvoiceModal.tsx
+++ b/client/src/Admin/pages/Financing/components/CreateInvoiceModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import type { Appointment } from '../../Calendar/types'
 import { API_BASE_URL } from '../../../../api'
 
@@ -19,6 +19,17 @@ export default function CreateInvoiceModal({ appointment, onClose }: Props) {
   const [discount, setDiscount] = useState('')
   const [taxEnabled, setTaxEnabled] = useState(false)
   const [taxPercent, setTaxPercent] = useState('')
+
+  useEffect(() => {
+    const rooms = (appointment as any).carpetRooms
+    const size = appointment.size
+    if (rooms && size) {
+      fetch(`${API_BASE_URL}/carpet-rate?size=${encodeURIComponent(size)}&rooms=${rooms}`)
+        .then((res) => res.json())
+        .then((d) => setCarpetPrice(String(d.rate)))
+        .catch(() => {})
+    }
+  }, [appointment])
 
   const subtotal =
     (parseFloat(price) || 0) +


### PR DESCRIPTION
## Summary
- update favicon to use `logo.png`
- pre-fill carpet total when appointment data contains carpet rooms
- redesign invoice PDF with blue headings and logo image

## Testing
- `npm run build` in `server`
- `npm run lint` in `client` *(fails: 55 errors)*

------
https://chatgpt.com/codex/tasks/task_e_687e369b6240832d9a2bd947c2dbf324