### PR TITLE
Add invoice email sending and carpet rate autofill

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -8,3 +8,9 @@ SSL_KEY_PATH=C:\Users\xbvga\172.18.128.1+2-key.pem
 
 # path to your certificate (the file ending in .pem)
 SSL_CERT_PATH=C:\Users\xbvga\172.18.128.1+2.pem
+
+# MailTrap SMTP settings
+MAILTRAP_HOST=sandbox.smtp.mailtrap.io
+MAILTRAP_PORT=2525
+MAILTRAP_USER=your-mailtrap-user
+MAILTRAP_API_KEY=your-mailtrap-api-key

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -15,6 +15,7 @@
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
         "google-auth-library": "^10.1.0",
+        "nodemailer": "^6.9.11",
         "pdf-lib": "^1.17.1"
       },
       "devDependencies": {
@@ -1491,6 +1492,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/nodemon": {

--- a/server/package.json
+++ b/server/package.json
@@ -20,7 +20,8 @@
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
     "google-auth-library": "^10.1.0",
-    "pdf-lib": "^1.17.1"
+    "pdf-lib": "^1.17.1",
+    "nodemailer": "^6.9.11"
   },
   "devDependencies": {
     "@types/cors": "^2.8.19",


### PR DESCRIPTION
## Summary
- auto fill carpet price in invoice modal using appointment data
- allow sending invoice via email and attach generated PDF
- implement helper to generate invoice PDFs
- expose `/invoices/:id/send` endpoint
- add nodemailer dependency
- use MailTrap SMTP settings for outgoing invoice emails

## Testing
- `npm --prefix client run lint` *(fails: Cannot find package '@eslint/js')*
- `npm --prefix server test` *(fails: no test specified)*
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_687e42151cb0832da2d5ca77c8ec4054