### PR TITLE
Fix persistence of form data

### DIFF
--- a/client/src/Admin/pages/Clients/components/ClientForm.tsx
+++ b/client/src/Admin/pages/Clients/components/ClientForm.tsx
@@ -43,7 +43,7 @@ export default function ClientForm() {
       alert(err.error || 'Failed to save')
       return
     }
-    sessionStorage.removeItem(storageKey)
+    localStorage.removeItem(storageKey)
     navigate('..')
   }
 

--- a/client/src/Admin/pages/Employees/components/EmployeeForm.tsx
+++ b/client/src/Admin/pages/Employees/components/EmployeeForm.tsx
@@ -59,7 +59,7 @@ export default function EmployeeForm() {
       alert(err.error || 'Failed to save')
       return
     }
-    sessionStorage.removeItem(storageKey)
+    localStorage.removeItem(storageKey)
     navigate('..')
   }
 
@@ -111,7 +111,7 @@ export default function EmployeeForm() {
         <button
           type="button"
           onClick={() => {
-            sessionStorage.removeItem(storageKey)
+            localStorage.removeItem(storageKey)
             navigate('..')
           }}
           className="bg-gray-300 px-4 py-2 rounded"

--- a/client/src/useFormPersistence.ts
+++ b/client/src/useFormPersistence.ts
@@ -6,24 +6,17 @@ export default function useFormPersistence<T>(
   setData: (d: T) => void,
 ) {
   useEffect(() => {
-    const stored = sessionStorage.getItem(key)
+    const stored = localStorage.getItem(key)
     if (stored) {
       try {
         setData(JSON.parse(stored))
       } catch {
-        // ignore
+        // ignore parse errors
       }
-      sessionStorage.removeItem(key)
     }
   }, [key, setData])
 
   useEffect(() => {
-    const handler = () => {
-      sessionStorage.setItem(key, JSON.stringify(data))
-    }
-    window.addEventListener('pagehide', handler)
-    return () => {
-      window.removeEventListener('pagehide', handler)
-    }
+    localStorage.setItem(key, JSON.stringify(data))
   }, [key, data])
 }


### PR DESCRIPTION
## Summary
- ensure client form state persists in local storage
- clear local storage after saving or cancelling forms

## Testing
- `npm --prefix client run lint` *(fails: no-empty, no-explicit-any, etc.)*
- `npm --prefix client run build`
- `npx --prefix client tsc -p client/tsconfig.json` *(fails: TS2345, TS2339, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_6881c22d145c832d82b5e70284cba8f2