### PR TITLE
Fix persistence of form data

### DIFF
--- a/client/src/Admin/pages/Clients/components/ClientForm.tsx
+++ b/client/src/Admin/pages/Clients/components/ClientForm.tsx
@@ -43,7 +43,7 @@ export default function ClientForm() {
       alert(err.error || 'Failed to save')
       return
     }
-    sessionStorage.removeItem(storageKey)
+    localStorage.removeItem(storageKey)
     navigate('..')
   }
 

--- a/client/src/Admin/pages/Employees/components/EmployeeForm.tsx
+++ b/client/src/Admin/pages/Employees/components/EmployeeForm.tsx
@@ -59,7 +59,7 @@ export default function EmployeeForm() {
       alert(err.error || 'Failed to save')
       return
     }
-    sessionStorage.removeItem(storageKey)
+    localStorage.removeItem(storageKey)
     navigate('..')
   }
 
@@ -111,7 +111,7 @@ export default function EmployeeForm() {
         <button
           type="button"
           onClick={() => {
-            sessionStorage.removeItem(storageKey)
+            localStorage.removeItem(storageKey)
             navigate('..')
           }}
           className="bg-gray-300 px-4 py-2 rounded"

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -29,6 +29,25 @@ function AppRoutes({ role, onLogin, onLogout }: RoutesProps) {
   const navigate = useNavigate()
   const location = useLocation()
 
+  // Restore last visited path so modals reopen after refresh
+  useEffect(() => {
+    if (role) {
+      const last = localStorage.getItem('lastPath')
+      if (last && last !== location.pathname) {
+        navigate(last, { replace: true })
+      }
+    }
+    // only run on mount
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  // Persist current path
+  useEffect(() => {
+    if (role) {
+      localStorage.setItem('lastPath', location.pathname)
+    }
+  }, [role, location.pathname])
+
   useEffect(() => {
     if (role && location.pathname === '/') {
       navigate('/dashboard', { replace: true })

--- a/client/src/useFormPersistence.ts
+++ b/client/src/useFormPersistence.ts
@@ -6,24 +6,17 @@ export default function useFormPersistence<T>(
   setData: (d: T) => void,
 ) {
   useEffect(() => {
-    const stored = sessionStorage.getItem(key)
+    const stored = localStorage.getItem(key)
     if (stored) {
       try {
         setData(JSON.parse(stored))
       } catch {
-        // ignore
+        // ignore parse errors
       }
-      sessionStorage.removeItem(key)
     }
   }, [key, setData])
 
   useEffect(() => {
-    const handler = () => {
-      sessionStorage.setItem(key, JSON.stringify(data))
-    }
-    window.addEventListener('pagehide', handler)
-    return () => {
-      window.removeEventListener('pagehide', handler)
-    }
+    localStorage.setItem(key, JSON.stringify(data))
   }, [key, data])
 }


### PR DESCRIPTION
## Summary
- ensure client form state persists in local storage
- clear local storage after saving or cancelling forms
- restore last visited path on reload so modals stay open

## Testing
- `npm --prefix client run lint` *(fails: no-unused-vars, no-explicit-any, etc.)*
- `npm --prefix client run build`
- `npx --prefix client tsc -p client/tsconfig.json` *(fails: TS2345, TS2339, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6881c22d145c832d82b5e70284cba8f2