### PR TITLE
Fix persistence of form data

### DIFF
--- a/client/src/Admin/pages/Clients/components/ClientForm.tsx
+++ b/client/src/Admin/pages/Clients/components/ClientForm.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import useFormPersistence from '../../../../useFormPersistence'
+import useFormPersistence, { clearFormPersistence } from '../../../../useFormPersistence'
 import { useNavigate, useParams } from 'react-router-dom'
 import { Client } from './types'
 import { API_BASE_URL, fetchJson } from '../../../../api'
@@ -43,17 +43,18 @@ export default function ClientForm() {
       alert(err.error || 'Failed to save')
       return
     }
-    sessionStorage.removeItem(storageKey)
+    clearFormPersistence(storageKey)
     navigate('..')
   }
 
   return (
     <form onSubmit={handleSubmit} className="p-4 space-y-3">
       <div>
-        <label className="block text-sm">
+        <label htmlFor="client-name" className="block text-sm">
           Name <span className="text-red-500">*</span>
         </label>
         <input
+          id="client-name"
           name="name"
           value={data.name}
           onChange={handleChange}
@@ -62,10 +63,11 @@ export default function ClientForm() {
         />
       </div>
       <div>
-        <label className="block text-sm">
+        <label htmlFor="client-number" className="block text-sm">
           Number <span className="text-red-500">*</span>
         </label>
         <input
+          id="client-number"
           name="number"
           value={data.number}
           onChange={handleNumberChange}
@@ -76,8 +78,14 @@ export default function ClientForm() {
         />
       </div>
       <div>
-        <label className="block text-sm">Notes</label>
-        <textarea name="notes" value={data.notes || ''} onChange={handleChange} className="w-full border p-2 rounded" />
+        <label htmlFor="client-notes" className="block text-sm">Notes</label>
+        <textarea
+          id="client-notes"
+          name="notes"
+          value={data.notes || ''}
+          onChange={handleChange}
+          className="w-full border p-2 rounded"
+        />
       </div>
       <button className="bg-blue-500 text-white px-4 py-2 rounded" type="submit">
         Save

--- a/client/src/Admin/pages/Employees/components/EmployeeForm.tsx
+++ b/client/src/Admin/pages/Employees/components/EmployeeForm.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { Employee } from './types'
 import { API_BASE_URL, fetchJson } from '../../../../api'
-import useFormPersistence from '../../../../useFormPersistence'
+import useFormPersistence, { clearFormPersistence } from '../../../../useFormPersistence'
 
 export default function EmployeeForm() {
   const { id } = useParams()
@@ -59,17 +59,18 @@ export default function EmployeeForm() {
       alert(err.error || 'Failed to save')
       return
     }
-    sessionStorage.removeItem(storageKey)
+    clearFormPersistence(storageKey)
     navigate('..')
   }
 
   return (
     <form onSubmit={handleSubmit} className="p-4 space-y-3">
       <div>
-        <label className="block text-sm">
+        <label htmlFor="employee-name" className="block text-sm">
           Name <span className="text-red-500">*</span>
         </label>
         <input
+          id="employee-name"
           name="name"
           value={data.name}
           onChange={handleChange}
@@ -78,10 +79,11 @@ export default function EmployeeForm() {
         />
       </div>
       <div>
-        <label className="block text-sm">
+        <label htmlFor="employee-number" className="block text-sm">
           Number <span className="text-red-500">*</span>
         </label>
         <input
+          id="employee-number"
           name="number"
           value={data.number}
           onChange={handleNumberChange}
@@ -92,8 +94,14 @@ export default function EmployeeForm() {
         />
       </div>
       <div>
-        <label className="block text-sm">Notes</label>
-        <textarea name="notes" value={data.notes || ''} onChange={handleChange} className="w-full border p-2 rounded" />
+        <label htmlFor="employee-notes" className="block text-sm">Notes</label>
+        <textarea
+          id="employee-notes"
+          name="notes"
+          value={data.notes || ''}
+          onChange={handleChange}
+          className="w-full border p-2 rounded"
+        />
       </div>
       <div className="flex items-center gap-2">
         <input
@@ -111,7 +119,7 @@ export default function EmployeeForm() {
         <button
           type="button"
           onClick={() => {
-            sessionStorage.removeItem(storageKey)
+            clearFormPersistence(storageKey)
             navigate('..')
           }}
           className="bg-gray-300 px-4 py-2 rounded"

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -29,6 +29,25 @@ function AppRoutes({ role, onLogin, onLogout }: RoutesProps) {
   const navigate = useNavigate()
   const location = useLocation()
 
+  // Restore last visited path so modals reopen after refresh
+  useEffect(() => {
+    if (role) {
+      const last = localStorage.getItem('lastPath')
+      if (last && last !== location.pathname) {
+        navigate(last, { replace: true })
+      }
+    }
+    // only run on mount
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  // Persist current path
+  useEffect(() => {
+    if (role) {
+      localStorage.setItem('lastPath', location.pathname)
+    }
+  }, [role, location.pathname])
+
   useEffect(() => {
     if (role && location.pathname === '/') {
       navigate('/dashboard', { replace: true })

--- a/client/src/useFormPersistence.ts
+++ b/client/src/useFormPersistence.ts
@@ -1,29 +1,48 @@
-import { useEffect } from 'react'
+import { useEffect, Dispatch, SetStateAction } from 'react'
 
-export default function useFormPersistence<T>(
+export default function useFormPersistence<T extends object>(
   key: string,
   data: T,
-  setData: (d: T) => void,
+  setData: Dispatch<SetStateAction<T>>,
 ) {
   useEffect(() => {
-    const stored = sessionStorage.getItem(key)
-    if (stored) {
-      try {
-        setData(JSON.parse(stored))
-      } catch {
-        // ignore
+    const merged: Partial<T> = {}
+    Object.keys(data).forEach((field) => {
+      const item = localStorage.getItem(`${key}-${field}`)
+      if (item !== null) {
+        try {
+          ;(merged as Record<string, unknown>)[field] = JSON.parse(item)
+        } catch {
+          ;(merged as Record<string, unknown>)[field] = item
+        }
       }
-      sessionStorage.removeItem(key)
+    })
+    const entire = localStorage.getItem(key)
+    if (entire) {
+      try {
+        Object.assign(merged, JSON.parse(entire))
+      } catch {
+        // ignore parse errors
+      }
     }
-  }, [key, setData])
+    if (Object.keys(merged).length > 0) {
+      setData({ ...data, ...merged })
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   useEffect(() => {
-    const handler = () => {
-      sessionStorage.setItem(key, JSON.stringify(data))
-    }
-    window.addEventListener('pagehide', handler)
-    return () => {
-      window.removeEventListener('pagehide', handler)
-    }
+    Object.entries(data).forEach(([field, value]) => {
+      localStorage.setItem(`${key}-${field}`, JSON.stringify(value))
+    })
+    localStorage.setItem(key, JSON.stringify(data))
   }, [key, data])
+}
+
+export function clearFormPersistence(key: string) {
+  Object.keys(localStorage).forEach((k) => {
+    if (k === key || k.startsWith(`${key}-`)) {
+      localStorage.removeItem(k)
+    }
+  })
 }


### PR DESCRIPTION
## Summary
- ensure form state persists in local storage per field
- clear local storage after saving or cancelling forms
- assign ids to all form inputs so fields reload after refresh

## Testing
- `npm --prefix client run lint` *(fails: no-unused-vars, no-undef, etc.)*
- `npm --prefix client run build`
- `npx --prefix client tsc -p client/tsconfig.json` *(fails: TS2339, TS2345, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6881c22d145c832d82b5e70284cba8f2