### PR TITLE
Add no-auth option for dev server

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -7,5 +7,6 @@ This project was bootstrapped with [Vite](https://vitejs.dev/) and includes `tai
 - `npm install` – install dependencies
 - `npm run dev` – start the development server
 - `npm run dev -ngrok` – start dev server and add the `ngrok-skip-browser-warning` header to all API requests
+- `npm run dev -- --no-auth` – start dev server and bypass Google login, automatically signing in as the owner
 
 The app starts with a login page where you can sign in with Google. To enable Google sign-in provide `VITE_GOOGLE_CLIENT_ID` in an `.env` file. API requests are sent to `VITE_API_BASE_URL`, which defaults to `http://localhost:3000`.

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -12,6 +12,16 @@ export default function App() {
       ? (stored as Role)
       : null
   })
+
+  useEffect(() => {
+    const noAuth =
+      import.meta.env.VITE_NO_AUTH === 'true' ||
+      import.meta.env.VITE_NO_AUTH === '1'
+    if (noAuth) {
+      setRole('OWNER')
+      localStorage.setItem('role', 'OWNER')
+    }
+  }, [])
   return (
     <BrowserRouter>
       <AppRoutes role={role} onLogin={setRole} onLogout={() => setRole(null)} />

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -7,6 +7,10 @@ export default defineConfig(() => {
   if (isNgrok) {
     process.env.VITE_NGROK = 'true'
   }
+  const noAuth = process.argv.includes('--no-auth') || process.argv.includes('-no-auth')
+  if (noAuth) {
+    process.env.VITE_NO_AUTH = 'true'
+  }
   return {
     plugins: [react()],
     server: {


### PR DESCRIPTION
## Summary
- add `--no-auth` flag detection in Vite config
- auto-login as OWNER in development when `VITE_NO_AUTH` is set
- document the new flag in the client README

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm run build` in `server`

------
https://chatgpt.com/codex/tasks/task_e_6884099cb4c8832d81da3da475f3e1a1