### PR TITLE
Add direct redirect for no-auth mode

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -7,5 +7,6 @@ This project was bootstrapped with [Vite](https://vitejs.dev/) and includes `tai
 - `npm install` – install dependencies
 - `npm run dev` – start the development server
 - `npm run dev -ngrok` – start dev server and add the `ngrok-skip-browser-warning` header to all API requests
+- `npm run dev -- --no-auth` – start dev server, automatically sign in as the owner, and jump straight to the dashboard
 
 The app starts with a login page where you can sign in with Google. To enable Google sign-in provide `VITE_GOOGLE_CLIENT_ID` in an `.env` file. API requests are sent to `VITE_API_BASE_URL`, which defaults to `http://localhost:3000`.

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,6 +7,13 @@ type Role = 'ADMIN' | 'OWNER' | 'EMPLOYEE'
 
 export default function App() {
   const [role, setRole] = useState<Role | null>(() => {
+    const noAuth =
+      import.meta.env.VITE_NO_AUTH === 'true' ||
+      import.meta.env.VITE_NO_AUTH === '1'
+    if (noAuth) {
+      localStorage.setItem('role', 'OWNER')
+      return 'OWNER'
+    }
     const stored = localStorage.getItem('role')
     return stored === 'ADMIN' || stored === 'OWNER' || stored === 'EMPLOYEE'
       ? (stored as Role)
@@ -48,15 +55,15 @@ function AppRoutes({ role, onLogin, onLogout }: RoutesProps) {
     }
   }, [role, location.pathname])
 
-  useEffect(() => {
-    if (role && location.pathname === '/') {
-      navigate('/dashboard', { replace: true })
-    }
-  }, [role, navigate, location.pathname])
+  // No dedicated redirect effect is needed when role is restored because
+  // the '/' route conditionally navigates to the dashboard.
 
   return (
     <Routes>
-      <Route path="/" element={<Login onLogin={onLogin} />} />
+      <Route
+        path="/"
+        element={role ? <Navigate to="/dashboard" replace /> : <Login onLogin={onLogin} />}
+      />
       <Route
         path="/dashboard/*"
         element={role ? <Dashboard role={role} onLogout={onLogout} /> : <Navigate to="/" replace />}

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -7,6 +7,10 @@ export default defineConfig(() => {
   if (isNgrok) {
     process.env.VITE_NGROK = 'true'
   }
+  const noAuth = process.argv.includes('--no-auth') || process.argv.includes('-no-auth')
+  if (noAuth) {
+    process.env.VITE_NO_AUTH = 'true'
+  }
   return {
     plugins: [react()],
     server: {


### PR DESCRIPTION
## Summary
- initialize role as OWNER when `--no-auth` is passed so no login screen is shown
- route `/` directly to `/dashboard` in no-auth mode
- document automatic dashboard redirect in README

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm run build` in `server` *(fails: missing node type definitions and packages)*

------
https://chatgpt.com/codex/tasks/task_e_6884099cb4c8832d81da3da475f3e1a1