### PR TITLE
Add revenue charts

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -9,7 +9,9 @@
       "version": "0.0.0",
       "dependencies": {
         "@react-oauth/google": "^0.12.2",
+        "chart.js": "^4.5.0",
         "react": "^19.1.0",
+        "react-chartjs-2": "^5.3.0",
         "react-dom": "^19.1.0",
         "react-router-dom": "^6.23.0"
       },
@@ -1058,6 +1060,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2059,6 +2067,18 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.0.tgz",
+      "integrity": "sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
       }
     },
     "node_modules/chokidar": {
@@ -3559,6 +3579,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-chartjs-2": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.3.0.tgz",
+      "integrity": "sha512-UfZZFnDsERI3c3CZGxzvNJd02SHjaSJ8kgW1djn65H1KK8rehwTjyrRKOG3VTMG8wtHZ5rgAO5oTHtHi9GCCmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": "^4.1.1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-dom": {

--- a/client/package.json
+++ b/client/package.json
@@ -11,7 +11,9 @@
   },
   "dependencies": {
     "@react-oauth/google": "^0.12.2",
+    "chart.js": "^4.5.0",
     "react": "^19.1.0",
+    "react-chartjs-2": "^5.3.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^6.23.0"
   },

--- a/client/src/Admin/pages/Financing/Revenue.tsx
+++ b/client/src/Admin/pages/Financing/Revenue.tsx
@@ -1,11 +1,250 @@
+import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
+import { Line, Pie } from 'react-chartjs-2'
+import {
+  ArcElement,
+  CategoryScale,
+  Chart as ChartJS,
+  Legend,
+  LineElement,
+  LinearScale,
+  PointElement,
+  Tooltip,
+} from 'chart.js'
+import { API_BASE_URL, fetchJson } from '../../../api'
+
+ChartJS.register(
+  ArcElement,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Tooltip,
+  Legend,
+)
+
+interface InvoiceData {
+  serviceDate: string
+  total: number
+  serviceType: string
+}
 
 export default function Revenue() {
+  const [data, setData] = useState<InvoiceData[]>([])
+
+  useEffect(() => {
+    fetchJson(`${API_BASE_URL}/revenue`)
+      .then((d) => setData(d))
+      .catch(() => setData([]))
+  }, [])
+
+  const group = (
+    items: InvoiceData[],
+    keyFn: (d: Date, it: InvoiceData) => string,
+  ): { labels: string[]; values: number[] } => {
+    const map: Record<string, number> = {}
+    for (const it of items) {
+      const d = new Date(it.serviceDate)
+      const key = keyFn(d, it)
+      map[key] = (map[key] || 0) + it.total
+    }
+    const labels = Object.keys(map).sort()
+    return { labels, values: labels.map((l) => map[l]) }
+  }
+
+  const daily = (() => {
+    const g = group(data, (d) => d.toISOString().slice(0, 10))
+    if (g.labels.length > 30) {
+      const start = g.labels.length - 30
+      g.labels = g.labels.slice(start)
+      g.values = g.values.slice(start)
+    }
+    return g
+  })()
+
+  const weekly = (() => {
+    const g = group(data, (d) => {
+      const day = new Date(d)
+      day.setDate(day.getDate() - day.getDay())
+      return day.toISOString().slice(0, 10)
+    })
+    if (g.labels.length > 12) {
+      const start = g.labels.length - 12
+      g.labels = g.labels.slice(start)
+      g.values = g.values.slice(start)
+    }
+    return g
+  })()
+
+  const monthly = (() => {
+    const g = group(data, (d) => `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`)
+    if (g.labels.length > 12) {
+      const start = g.labels.length - 12
+      g.labels = g.labels.slice(start)
+      g.values = g.values.slice(start)
+    }
+    return g
+  })()
+
+  const quarterly = (() => {
+    const g = group(data, (d) => `${d.getFullYear()}-Q${Math.floor(d.getMonth() / 3) + 1}`)
+    if (g.labels.length > 8) {
+      const start = g.labels.length - 8
+      g.labels = g.labels.slice(start)
+      g.values = g.values.slice(start)
+    }
+    return g
+  })()
+
+  const yearly = group(data, (d) => String(d.getFullYear()))
+
+  const byType = (() => {
+    const map: Record<string, number> = {}
+    for (const it of data) {
+      map[it.serviceType] = (map[it.serviceType] || 0) + it.total
+    }
+    const labels = Object.keys(map)
+    return { labels, values: labels.map((l) => map[l]) }
+  })()
+
+  const monthLabels = monthly.labels
+  const thisMonth = monthly.values[monthLabels.length - 1] || 0
+  const lastMonth = monthly.values[monthLabels.length - 2] || 0
+  const diff = thisMonth - lastMonth
+  const upDown =
+    lastMonth === 0 ? 0 : Math.round((diff / lastMonth) * 100)
+
   return (
-    <div className="p-4">
-      <Link to=".." className="text-blue-500 text-sm">&larr; Back</Link>
+    <div className="p-4 space-y-8 pb-16">
+      <Link to=".." className="text-blue-500 text-sm">
+        &larr; Back
+      </Link>
       <h2 className="text-xl font-semibold mb-2">Revenue</h2>
-      {/* TODO: add revenue table */}
+
+      <div className="grid gap-8 md:grid-cols-2">
+        <div>
+          <h3 className="font-medium mb-2">Daily (last 30 days)</h3>
+          <div className="h-64">
+            <Line
+            data={{
+              labels: daily.labels,
+              datasets: [
+                {
+                  label: 'Revenue',
+                  data: daily.values,
+                  borderColor: 'rgb(99, 102, 241)',
+                  backgroundColor: 'rgba(99, 102, 241, 0.5)',
+                },
+              ],
+            }}
+            options={{ responsive: true, maintainAspectRatio: false }}
+            />
+          </div>
+        </div>
+        <div>
+          <h3 className="font-medium mb-2">Weekly (last 12 weeks)</h3>
+          <div className="h-64">
+            <Line
+            data={{
+              labels: weekly.labels,
+              datasets: [
+                {
+                  label: 'Revenue',
+                  data: weekly.values,
+                  borderColor: 'rgb(16, 185, 129)',
+                  backgroundColor: 'rgba(16, 185, 129, 0.5)',
+                },
+              ],
+            }}
+            options={{ responsive: true, maintainAspectRatio: false }}
+            />
+          </div>
+        </div>
+        <div>
+          <h3 className="font-medium mb-2">Monthly (last 12 months)</h3>
+          <div className="h-64">
+            <Line
+            data={{
+              labels: monthly.labels,
+              datasets: [
+                {
+                  label: 'Revenue',
+                  data: monthly.values,
+                  borderColor: 'rgb(59, 130, 246)',
+                  backgroundColor: 'rgba(59, 130, 246, 0.5)',
+                },
+              ],
+            }}
+            options={{ responsive: true, maintainAspectRatio: false }}
+            />
+          </div>
+        </div>
+        <div>
+          <h3 className="font-medium mb-2">Quarterly (last 8 quarters)</h3>
+          <div className="h-64">
+            <Line
+            data={{
+              labels: quarterly.labels,
+              datasets: [
+                {
+                  label: 'Revenue',
+                  data: quarterly.values,
+                  borderColor: 'rgb(234, 179, 8)',
+                  backgroundColor: 'rgba(234, 179, 8, 0.5)',
+                },
+              ],
+            }}
+            options={{ responsive: true, maintainAspectRatio: false }}
+            />
+          </div>
+        </div>
+        <div>
+          <h3 className="font-medium mb-2">Yearly</h3>
+          <div className="h-64">
+            <Line
+            data={{
+              labels: yearly.labels,
+              datasets: [
+                {
+                  label: 'Revenue',
+                  data: yearly.values,
+                  borderColor: 'rgb(249, 115, 22)',
+                  backgroundColor: 'rgba(249, 115, 22, 0.5)',
+                },
+              ],
+            }}
+            options={{ responsive: true, maintainAspectRatio: false }}
+            />
+          </div>
+        </div>
+        <div>
+          <h3 className="font-medium mb-2">By Service Type</h3>
+          <div className="h-64">
+            <Pie
+            data={{
+              labels: byType.labels,
+              datasets: [
+                {
+                  data: byType.values,
+                  backgroundColor: [
+                    'rgb(99,102,241)',
+                    'rgb(16,185,129)',
+                    'rgb(59,130,246)',
+                    'rgb(234,179,8)',
+                    'rgb(249,115,22)',
+                  ],
+                },
+              ],
+            }}
+            options={{ responsive: true, maintainAspectRatio: false }}
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className="pt-6 text-lg font-medium">
+        {`This month: $${thisMonth.toFixed(2)} (${upDown >= 0 ? '+' : ''}${upDown}% vs last month)`}
+      </div>
     </div>
   )
 }

--- a/client/src/Admin/pages/Financing/components/CreateInvoiceModal.tsx
+++ b/client/src/Admin/pages/Financing/components/CreateInvoiceModal.tsx
@@ -51,6 +51,7 @@ export default function CreateInvoiceModal({ appointment, onClose }: Props) {
       discount: discount ? parseFloat(discount) : undefined,
       taxPercent: taxEnabled ? parseFloat(taxPercent) || 0 : undefined,
     }
+    const newWindow = window.open('', '_blank')
     const res = await fetch(`${API_BASE_URL}/invoices`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', 'ngrok-skip-browser-warning': '1' },
@@ -58,9 +59,15 @@ export default function CreateInvoiceModal({ appointment, onClose }: Props) {
     })
     if (res.ok) {
       const data = await res.json()
-      window.open(`${API_BASE_URL}/invoices/${data.id}/pdf`, '_blank')
+      const url = `${API_BASE_URL}/invoices/${data.id}/pdf`
+      if (newWindow) {
+        newWindow.location.href = url
+      } else {
+        window.location.href = url
+      }
       onClose()
     } else {
+      if (newWindow) newWindow.close()
       alert('Failed to create invoice')
     }
   }
@@ -78,6 +85,7 @@ export default function CreateInvoiceModal({ appointment, onClose }: Props) {
       discount: discount ? parseFloat(discount) : undefined,
       taxPercent: taxEnabled ? parseFloat(taxPercent) || 0 : undefined,
     }
+    const newWindow = window.open('', '_blank')
     const res = await fetch(`${API_BASE_URL}/invoices`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', 'ngrok-skip-browser-warning': '1' },
@@ -93,9 +101,15 @@ export default function CreateInvoiceModal({ appointment, onClose }: Props) {
           body: JSON.stringify({ email }),
         })
       }
-      window.open(`${API_BASE_URL}/invoices/${data.id}/pdf`, '_blank')
+      const url = `${API_BASE_URL}/invoices/${data.id}/pdf`
+      if (newWindow) {
+        newWindow.location.href = url
+      } else {
+        window.location.href = url
+      }
       onClose()
     } else {
+      if (newWindow) newWindow.close()
       alert('Failed to create invoice')
     }
   }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1178,6 +1178,25 @@ app.post('/invoices/:id/send', async (req: Request, res: Response) => {
   }
 })
 
+app.get('/revenue', async (_req: Request, res: Response) => {
+  try {
+    const invoices = await prisma.invoice.findMany({
+      orderBy: { serviceDate: 'asc' },
+      select: { serviceDate: true, total: true, serviceType: true },
+    })
+    res.json(
+      invoices.map((i) => ({
+        serviceDate: i.serviceDate.toISOString(),
+        total: i.total,
+        serviceType: i.serviceType,
+      }))
+    )
+  } catch (err) {
+    console.error('Failed to fetch revenue:', err)
+    res.status(500).json({ error: 'Failed to fetch revenue' })
+  }
+})
+
 app.get('/payroll/due', async (_req: Request, res: Response) => {
   const items = await prisma.payrollItem.findMany({
     where: { paid: false },


### PR DESCRIPTION
## Summary
- create `/revenue` API for invoice totals
- use `chart.js` on client
- add Revenue dashboard with daily/weekly/monthly/quarterly/yearly graphs
- improve chart layout with fixed-height containers
- fix invoice creation so PDFs open reliably on mobile

## Testing
- `npm test` *(fails: Missing script)*
- `npm test` in `server` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6885515725cc832d81719f76ed7f64ef