### PR TITLE
Add carpet price field

### DIFF
--- a/client/src/Admin/pages/Calendar/types.ts
+++ b/client/src/Admin/pages/Calendar/types.ts
@@ -27,6 +27,7 @@ export interface Appointment {
   paymentMethod?: 'CASH' | 'ZELLE' | 'VENMO' | 'PAYPAL' | 'OTHER' | 'CHECK'
   tip?: number
   carpetRooms?: number
+  carpetPrice?: number
   reoccurring?: boolean
   observe?: boolean
   status?:

--- a/client/src/Admin/pages/Financing/components/CreateInvoiceModal.tsx
+++ b/client/src/Admin/pages/Financing/components/CreateInvoiceModal.tsx
@@ -15,12 +15,21 @@ export default function CreateInvoiceModal({ appointment, onClose }: Props) {
   const [time, setTime] = useState(appointment.time)
   const [serviceType, setServiceType] = useState(appointment.type)
   const [price, setPrice] = useState(String(appointment.price ?? ''))
-  const [carpetPrice, setCarpetPrice] = useState('')
+  const [carpetPrice, setCarpetPrice] = useState(
+    (appointment as any).carpetPrice != null
+      ? String((appointment as any).carpetPrice)
+      : ''
+  )
   const [discount, setDiscount] = useState('')
   const [taxEnabled, setTaxEnabled] = useState(false)
   const [taxPercent, setTaxPercent] = useState('')
 
   useEffect(() => {
+    const cp = (appointment as any).carpetPrice
+    if (cp != null) {
+      setCarpetPrice(String(cp))
+      return
+    }
     const rooms = (appointment as any).carpetRooms
     const size = appointment.size
     if (rooms != null && size) {

--- a/server/prisma/migrations/20250726231029_carpet_price/migration.sql
+++ b/server/prisma/migrations/20250726231029_carpet_price/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Appointment" ADD COLUMN "carpetPrice" DOUBLE PRECISION;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -61,6 +61,7 @@ model Appointment {
   paymentMethod   PaymentMethod
   tip             Float           @default(0)
   carpetRooms     Int?
+  carpetPrice     Float?
   reoccurring     Boolean         @default(false)
   status          AppointmentStatus @default(APPOINTED)
   observe         Boolean         @default(false)


### PR DESCRIPTION
## Summary
- support carpet price on appointments
- migrate DB to add `carpetPrice`
- compute and store default carpet price when creating appointments
- allow editing carpet price in appointment template form
- use stored carpet price when creating invoices

## Testing
- `npm run build` in `client`
- `npm run build` in `server`


------
https://chatgpt.com/codex/tasks/task_e_68855fc0d3cc832db500fe480ea6c1b1