### PR TITLE
Add carpet settings to appointment templates

### DIFF
--- a/client/src/Admin/pages/Calendar/types.ts
+++ b/client/src/Admin/pages/Calendar/types.ts
@@ -8,7 +8,8 @@ export interface AppointmentTemplate {
   clientId: number
   cityStateZip?: string // used for notes
   carpetEnabled?: boolean
-  carpetRooms?: string
+  carpetRooms?: number
+  carpetPrice?: number
 }
 
 export interface Appointment {

--- a/server/prisma/migrations/20250727235900_template_carpet/migration.sql
+++ b/server/prisma/migrations/20250727235900_template_carpet/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "AppointmentTemplate" ADD COLUMN "carpetRooms" INTEGER;
+ALTER TABLE "AppointmentTemplate" ADD COLUMN "carpetPrice" DOUBLE PRECISION;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -85,6 +85,8 @@ model AppointmentTemplate {
   address           String
   cityStateZip      String?
   price             Float
+  carpetRooms      Int?
+  carpetPrice      Float?
   clientId          Int
   client            Client             @relation(fields: [clientId], references: [id])
   employeeTemplates EmployeeTemplate[]


### PR DESCRIPTION
## Summary
- support carpetRooms and carpetPrice on `AppointmentTemplate`
- compute default carpet price in appointment template modal and allow override
- use template carpet info when creating appointments
- update database schema and create migration

## Testing
- `npm run build` in `server`
- `npm run build` in `client`
- `npm test` in `server` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6885643f3098832d8a79fc52cee32177