### PR TITLE
Remove carpet price box from templates

### DIFF
--- a/client/src/Admin/pages/Calendar/components/CreateAppointmentModal.tsx
+++ b/client/src/Admin/pages/Calendar/components/CreateAppointmentModal.tsx
@@ -549,7 +549,7 @@ const preserveTeamRef = useRef(false)
       notes: t.cityStateZip || '',
       carpetEnabled: !!t.carpetEnabled,
       carpetRooms: t.carpetRooms || '',
-      carpetPrice: '',
+      carpetPrice: t.carpetPrice != null ? String(t.carpetPrice) : '',
     })
     setEditing(true)
     setEditingTemplateId(selectedTemplate)
@@ -583,7 +583,9 @@ const preserveTeamRef = useRef(false)
     }
     if (templateForm.carpetEnabled) {
       payload.carpetRooms = parseInt(templateForm.carpetRooms, 10) || 0
-      payload.carpetPrice = parseFloat(templateForm.carpetPrice) || 0
+      if (editing) {
+        payload.carpetPrice = parseFloat(templateForm.carpetPrice) || 0
+      }
     }
     const res = await fetch(`${API_BASE_URL}/appointment-templates`, {
       method: 'POST',
@@ -602,7 +604,9 @@ const preserveTeamRef = useRef(false)
             ...t,
             carpetEnabled: templateForm.carpetEnabled,
             carpetRooms: templateForm.carpetRooms,
-            carpetPrice: parseFloat(templateForm.carpetPrice),
+            carpetPrice: editing
+              ? parseFloat(templateForm.carpetPrice)
+              : t.carpetPrice,
           },
         ]
       })
@@ -918,7 +922,7 @@ const preserveTeamRef = useRef(false)
                         setTemplateForm({ ...templateForm, carpetRooms: e.target.value })
                       }
                     />
-                    {defaultCarpetPrice !== null && !overrideCarpetPrice ? (
+                    {editing && defaultCarpetPrice !== null && !overrideCarpetPrice && (
                       <div className="mt-2 flex items-center gap-2">
                         <span>
                           Carpet Price: ${defaultCarpetPrice.toFixed(2)}
@@ -931,7 +935,8 @@ const preserveTeamRef = useRef(false)
                           Edit price
                         </button>
                       </div>
-                    ) : (
+                    )}
+                    {editing && overrideCarpetPrice && (
                       <div>
                         <h4 className="font-light mt-2">Carpet Price</h4>
                         <input


### PR DESCRIPTION
## Summary
- don't include carpet price when creating appointment templates
- only show carpet price override option when editing a template

## Testing
- `npx vite build` *(fails: Cannot find package 'vite')*
- `npm run build` in server *(fails: cannot find module typings)*

------
https://chatgpt.com/codex/tasks/task_e_688568f8ac44832d915d0501027318c5