### PR TITLE
Add Instructions field to appointment templates

### DIFF
--- a/client/src/Admin/pages/Calendar/components/CreateAppointmentModal.tsx
+++ b/client/src/Admin/pages/Calendar/components/CreateAppointmentModal.tsx
@@ -85,6 +85,7 @@ export default function CreateAppointmentModal({ onClose, onCreated, initialClie
     address: '',
     price: '',
     notes: '',
+    instructions: '',
     carpetEnabled: false,
     carpetRooms: '',
     carpetPrice: '',
@@ -302,6 +303,7 @@ const preserveTeamRef = useRef(false)
       address: '',
       price: '',
       notes: '',
+      instructions: '',
       carpetEnabled: false,
       carpetRooms: '',
       carpetPrice: '',
@@ -547,6 +549,7 @@ const preserveTeamRef = useRef(false)
       address: t.address,
       price: String(t.price),
       notes: t.cityStateZip || '',
+      instructions: t.instructions || '',
       carpetEnabled: !!t.carpetEnabled,
       carpetRooms: t.carpetRooms || '',
       carpetPrice: t.carpetPrice != null ? String(t.carpetPrice) : '',
@@ -580,6 +583,7 @@ const preserveTeamRef = useRef(false)
       address: templateForm.address,
       price: parseFloat(templateForm.price),
       notes: templateForm.notes || undefined,
+      instructions: templateForm.instructions || undefined,
     }
     if (templateForm.carpetEnabled) {
       payload.carpetRooms = parseInt(templateForm.carpetRooms, 10) || 0
@@ -895,6 +899,16 @@ const preserveTeamRef = useRef(false)
                   value={templateForm.notes}
                   onChange={(e) => setTemplateForm({ ...templateForm, notes: e.target.value })}
                 />
+                <h4 className="font-light">Instructions:</h4>
+                <textarea
+                  id="appointment-template-instructions"
+                  className="w-full border p-2 rounded text-base"
+                  placeholder="Instructions"
+                  value={templateForm.instructions}
+                  onChange={(e) =>
+                    setTemplateForm({ ...templateForm, instructions: e.target.value })
+                  }
+                />
                 <label className="flex items-center gap-2">
                   <input
                     type="checkbox"
@@ -1004,6 +1018,7 @@ const preserveTeamRef = useRef(false)
                       <div>Address: {t.address}</div>
                       <div>Price: ${t.price.toFixed(2)}</div>
                       {t.cityStateZip && <div>Notes: {t.cityStateZip}</div>}
+                      {t.instructions && <div>Instructions: {t.instructions}</div>}
                       {t.carpetEnabled && (
                         <div>Carpet Rooms: {t.carpetRooms}</div>
                       )}

--- a/client/src/Admin/pages/Calendar/types.ts
+++ b/client/src/Admin/pages/Calendar/types.ts
@@ -7,6 +7,7 @@ export interface AppointmentTemplate {
   price: number
   clientId: number
   cityStateZip?: string // used for notes
+  instructions?: string
   carpetEnabled?: boolean
   carpetRooms?: number
   carpetPrice?: number

--- a/server/prisma/migrations/20250728000000_template_instructions/migration.sql
+++ b/server/prisma/migrations/20250728000000_template_instructions/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "AppointmentTemplate" ADD COLUMN "instructions" TEXT;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -85,6 +85,7 @@ model AppointmentTemplate {
   address           String
   cityStateZip      String?
   price             Float
+  instructions     String?
   carpetRooms      Int?
   carpetPrice      Float?
   clientId          Int

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -481,6 +481,7 @@ app.post('/appointment-templates', async (req: Request, res: Response) => {
       address,
       price,
       notes,
+      instructions,
       carpetRooms,
       carpetPrice,
     } = req.body as {
@@ -491,6 +492,7 @@ app.post('/appointment-templates', async (req: Request, res: Response) => {
       address?: string
       price?: number
       notes?: string
+      instructions?: string
       carpetRooms?: number
       carpetPrice?: number
     }
@@ -513,6 +515,7 @@ app.post('/appointment-templates', async (req: Request, res: Response) => {
         address,
         cityStateZip: notes,
         price,
+        instructions,
         carpetRooms: carpetRooms ?? null,
         carpetPrice: carpetPrice ?? null,
         client: { connect: { id: clientId } },


### PR DESCRIPTION
## Summary
- add `instructions` column in Prisma schema with migration
- expose `instructions` in appointment template API
- allow creating/editing instructions from the dashboard UI

## Testing
- `npm run build` in `server`
- `npm install` and `npm run build` in `client`


------
https://chatgpt.com/codex/tasks/task_e_6885707b6894832dbdd2783913e48a2b