### PR TITLE
Update appointment template forms

### DIFF
--- a/client/src/Admin/pages/Calendar/components/CreateAppointmentModal.tsx
+++ b/client/src/Admin/pages/Calendar/components/CreateAppointmentModal.tsx
@@ -548,7 +548,7 @@ const preserveTeamRef = useRef(false)
       size: t.size || '',
       address: t.address,
       price: String(t.price),
-      notes: t.cityStateZip || '',
+      notes: t.notes || '',
       instructions: t.instructions || '',
       carpetEnabled: !!t.carpetEnabled,
       carpetRooms: t.carpetRooms || '',
@@ -891,14 +891,6 @@ const preserveTeamRef = useRef(false)
                   value={templateForm.address}
                   onChange={(e) => setTemplateForm({ ...templateForm, address: e.target.value })}
                 />
-                  <h4 className="font-light">Notes: </h4>
-                <textarea
-                  id="appointment-template-notes"
-                  className="w-full border p-2 rounded text-base"
-                  placeholder="Notes"
-                  value={templateForm.notes}
-                  onChange={(e) => setTemplateForm({ ...templateForm, notes: e.target.value })}
-                />
                 <h4 className="font-light">Instructions:</h4>
                 <textarea
                   id="appointment-template-instructions"
@@ -908,6 +900,14 @@ const preserveTeamRef = useRef(false)
                   onChange={(e) =>
                     setTemplateForm({ ...templateForm, instructions: e.target.value })
                   }
+                />
+                <h4 className="font-light">Notes: </h4>
+                <textarea
+                  id="appointment-template-notes"
+                  className="w-full border p-2 rounded text-base"
+                  placeholder="Notes"
+                  value={templateForm.notes}
+                  onChange={(e) => setTemplateForm({ ...templateForm, notes: e.target.value })}
                 />
                 <label className="flex items-center gap-2">
                   <input
@@ -1017,7 +1017,7 @@ const preserveTeamRef = useRef(false)
                       {t.size && <div>Size: {t.size}</div>}
                       <div>Address: {t.address}</div>
                       <div>Price: ${t.price.toFixed(2)}</div>
-                      {t.cityStateZip && <div>Notes: {t.cityStateZip}</div>}
+                      {t.notes && <div>Notes: {t.notes}</div>}
                       {t.instructions && <div>Instructions: {t.instructions}</div>}
                       {t.carpetEnabled && (
                         <div>Carpet Rooms: {t.carpetRooms}</div>

--- a/client/src/Admin/pages/Calendar/components/DayTimeline.tsx
+++ b/client/src/Admin/pages/Calendar/components/DayTimeline.tsx
@@ -342,6 +342,9 @@ const handleSave = async () => {
             {selected.price != null && (
               <div className="text-sm">Price: ${selected.price}</div>
             )}
+            {selected.cityStateZip && (
+              <div className="text-sm">Instructions: {selected.cityStateZip}</div>
+            )}
             {selected.notes && (
               <div className="text-sm">Notes: {selected.notes}</div>
             )}

--- a/client/src/Admin/pages/Calendar/types.ts
+++ b/client/src/Admin/pages/Calendar/types.ts
@@ -6,7 +6,8 @@ export interface AppointmentTemplate {
   address: string
   price: number
   clientId: number
-  cityStateZip?: string // used for notes
+  cityStateZip?: string
+  notes?: string
   instructions?: string
   carpetEnabled?: boolean
   carpetRooms?: number

--- a/server/prisma/migrations/20250728010000_template_notes/migration.sql
+++ b/server/prisma/migrations/20250728010000_template_notes/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "AppointmentTemplate" ADD COLUMN "notes" TEXT;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -86,6 +86,7 @@ model AppointmentTemplate {
   cityStateZip      String?
   price             Float
   instructions     String?
+  notes            String?
   carpetRooms      Int?
   carpetPrice      Float?
   clientId          Int

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -513,9 +513,10 @@ app.post('/appointment-templates', async (req: Request, res: Response) => {
         type,
         size,
         address,
-        cityStateZip: notes,
+        cityStateZip: null,
         price,
         instructions,
+        notes,
         carpetRooms: carpetRooms ?? null,
         carpetPrice: carpetPrice ?? null,
         client: { connect: { id: clientId } },
@@ -757,7 +758,7 @@ app.post('/appointments/recurring', async (req: Request, res: Response) => {
           time,
           type: template.type,
           address: template.address,
-          cityStateZip: template.cityStateZip,
+          cityStateZip: template.instructions ?? undefined,
           size: template.size,
           hours: hours ?? null,
           price: template.price,
@@ -766,7 +767,9 @@ app.post('/appointments/recurring', async (req: Request, res: Response) => {
           carpetRooms: carpetRoomsFinal,
           carpetPrice: finalCarpetPrice ?? null,
           paymentMethod: paymentMethod as any,
-          notes: paymentMethodNote || undefined,
+          notes:
+            [template.notes, paymentMethodNote].filter(Boolean).join(' | ') ||
+            undefined,
           status: 'REOCCURRING',
           lineage,
           reoccurring: true,
@@ -858,7 +861,7 @@ app.post('/appointments', async (req: Request, res: Response) => {
         time,
         type: template.type,
         address: template.address,
-        cityStateZip: template.cityStateZip,
+        cityStateZip: template.instructions ?? undefined,
         size: template.size,
         hours: hours ?? null,
         price: template.price,
@@ -867,7 +870,9 @@ app.post('/appointments', async (req: Request, res: Response) => {
         carpetRooms: carpetRoomsFinal,
         carpetPrice: finalCarpetPrice ?? null,
         paymentMethod: paymentMethod as any, // or cast to your enum
-        notes: paymentMethodNote || undefined,
+        notes:
+          [template.notes, paymentMethodNote].filter(Boolean).join(' | ') ||
+          undefined,
         status: status as any,
         lineage: 'single',
         // only include the relation if there are IDs
@@ -936,9 +941,10 @@ app.put('/appointments/:id', async (req: Request, res: Response) => {
       if (!template) return res.status(400).json({ error: 'Invalid templateId' })
       data.type = template.type
       data.address = template.address
-      data.cityStateZip = template.cityStateZip ?? undefined
+      data.cityStateZip = template.instructions ?? undefined
       data.size = template.size ?? undefined
       data.price = template.price
+      data.notes = template.notes ?? data.notes
       if (carpetRooms === undefined && template.carpetRooms != null) {
         data.carpetRooms = template.carpetRooms
       }


### PR DESCRIPTION
## Summary
- reorder instructions above notes in create appointment template
- display instructions and notes in appointment view modal
- add notes field to appointment templates and propagate to appointments

## Testing
- `npm run lint` *(fails: 71 errors, 16 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_688574596708832dbd0734a5d28dce5d