### PR TITLE
Fix carpet checkbox when template has rooms

### DIFF
--- a/client/src/Admin/pages/Calendar/components/CreateAppointmentModal.tsx
+++ b/client/src/Admin/pages/Calendar/components/CreateAppointmentModal.tsx
@@ -429,7 +429,8 @@ const preserveTeamRef = useRef(false)
       setSelectedOption(0)
     }
     const t = templates.find((tt) => tt.id === selectedTemplate)
-    setCarpetEnabled(!!t?.carpetEnabled)
+    const hasCarpet = t?.carpetEnabled ?? (t?.carpetRooms != null && t.carpetRooms > 0)
+    setCarpetEnabled(!!hasCarpet)
     setCarpetRooms(t?.carpetRooms || '')
   }, [selectedTemplate, templates])
 


### PR DESCRIPTION
## Summary
- auto-enable carpet option when a selected template has carpet rooms
- run eslint and npm test

## Testing
- `npm run lint` *(fails: 71 errors)*
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688585a4a7dc832db39c2b0051926526