### PR TITLE
Fix carpet team reset when changing options

### DIFF
--- a/client/src/Admin/pages/Calendar/components/CreateAppointmentModal.tsx
+++ b/client/src/Admin/pages/Calendar/components/CreateAppointmentModal.tsx
@@ -282,8 +282,8 @@ const preserveTeamRef = useRef(false)
     }
   }, [selectedTemplate, templates, editingTemplateId])
 
-  const resetCarpet = () => {
-    setCarpetEnabled(false)
+  const resetCarpet = (disable: boolean = true) => {
+    if (disable) setCarpetEnabled(false)
     setCarpetRooms('')
     setCarpetEmployees([])
     setCarpetRate(null)
@@ -1296,7 +1296,7 @@ const preserveTeamRef = useRef(false)
                 onClick={() => {
                   setSelectedOption(idx)
                   setSelectedEmployees([])
-                  resetCarpet()
+                  resetCarpet(false)
                 }}
               >
                 {o.sem} SEM / {o.com} COM - {o.hours}h


### PR DESCRIPTION
## Summary
- preserve carpet cleaning requirement when switching team options

## Testing
- `npm run build` in `client`
- `npm run build` in `server`


------
https://chatgpt.com/codex/tasks/task_e_6885875d15e8832da5000e1377542a28