### PR TITLE
Hide carpet section for templates without carpet

### DIFF
--- a/client/src/Admin/pages/Calendar/components/CreateAppointmentModal.tsx
+++ b/client/src/Admin/pages/Calendar/components/CreateAppointmentModal.tsx
@@ -126,6 +126,10 @@ export default function CreateAppointmentModal({ onClose, onCreated, initialClie
     persisted.overrideCarpetPrice ?? false,
   )
 
+  const selectedTemplateData = selectedTemplate
+    ? templates.find((tt) => tt.id === selectedTemplate)
+    : null
+
   // recurring options
   const recurringOptions = [
     'Weekly',
@@ -910,80 +914,84 @@ const preserveTeamRef = useRef(false)
                   value={templateForm.notes}
                   onChange={(e) => setTemplateForm({ ...templateForm, notes: e.target.value })}
                 />
-                <label className="flex items-center gap-2">
-                  <input
-                    type="checkbox"
-                    checked={templateForm.carpetEnabled}
-                    onChange={(e) => {
-                      setTemplateForm({
-                        ...templateForm,
-                        carpetEnabled: e.target.checked,
-                        ...(e.target.checked ? {} : { carpetRooms: '' }),
-                      })
-                    }}
-                  />
-                  <span>Carpet Cleaning</span>
-                </label>
-                {templateForm.carpetEnabled && (
-                  <div>
-                    <h4 className="font-light">How many rooms?</h4>
-                    <input
-                      id="appointment-template-carpet-rooms"
-                      type="number"
-                      min="1"
-                      className="w-full border p-2 rounded text-base"
-                      value={templateForm.carpetRooms}
-                      onChange={(e) =>
-                        setTemplateForm({ ...templateForm, carpetRooms: e.target.value })
-                      }
-                    />
-                    {editing && defaultCarpetPrice !== null && !overrideCarpetPrice && (
-                      <div className="mt-2 flex items-center gap-2">
-                        <span>
-                          Carpet Price: ${defaultCarpetPrice.toFixed(2)}
-                        </span>
-                        <button
-                          type="button"
-                          className="text-sm text-blue-500"
-                          onClick={() => setOverrideCarpetPrice(true)}
-                        >
-                          Edit price
-                        </button>
-                      </div>
-                    )}
-                    {editing && overrideCarpetPrice && (
+                {selectedTemplateData?.carpetRooms != null && (
+                  <>
+                    <label className="flex items-center gap-2">
+                      <input
+                        type="checkbox"
+                        checked={templateForm.carpetEnabled}
+                        onChange={(e) => {
+                          setTemplateForm({
+                            ...templateForm,
+                            carpetEnabled: e.target.checked,
+                            ...(e.target.checked ? {} : { carpetRooms: '' }),
+                          })
+                        }}
+                      />
+                      <span>Carpet Cleaning</span>
+                    </label>
+                    {templateForm.carpetEnabled && (
                       <div>
-                        <h4 className="font-light mt-2">Carpet Price</h4>
+                        <h4 className="font-light">How many rooms?</h4>
                         <input
-                          id="appointment-template-carpet-price"
+                          id="appointment-template-carpet-rooms"
                           type="number"
+                          min="1"
                           className="w-full border p-2 rounded text-base"
-                          value={templateForm.carpetPrice}
+                          value={templateForm.carpetRooms}
                           onChange={(e) =>
-                            setTemplateForm({
-                              ...templateForm,
-                              carpetPrice: e.target.value,
-                            })
+                            setTemplateForm({ ...templateForm, carpetRooms: e.target.value })
                           }
                         />
-                        {defaultCarpetPrice !== null && (
-                          <button
-                            type="button"
-                            className="text-sm text-blue-500 mt-1"
-                            onClick={() => {
-                              setOverrideCarpetPrice(false)
-                              setTemplateForm({
-                                ...templateForm,
-                                carpetPrice: String(defaultCarpetPrice),
-                              })
-                            }}
-                          >
-                            Use default
-                          </button>
+                        {editing && defaultCarpetPrice !== null && !overrideCarpetPrice && (
+                          <div className="mt-2 flex items-center gap-2">
+                            <span>
+                              Carpet Price: ${defaultCarpetPrice.toFixed(2)}
+                            </span>
+                            <button
+                              type="button"
+                              className="text-sm text-blue-500"
+                              onClick={() => setOverrideCarpetPrice(true)}
+                            >
+                              Edit price
+                            </button>
+                          </div>
+                        )}
+                        {editing && overrideCarpetPrice && (
+                          <div>
+                            <h4 className="font-light mt-2">Carpet Price</h4>
+                            <input
+                              id="appointment-template-carpet-price"
+                              type="number"
+                              className="w-full border p-2 rounded text-base"
+                              value={templateForm.carpetPrice}
+                              onChange={(e) =>
+                                setTemplateForm({
+                                  ...templateForm,
+                                  carpetPrice: e.target.value,
+                                })
+                              }
+                            />
+                            {defaultCarpetPrice !== null && (
+                              <button
+                                type="button"
+                                className="text-sm text-blue-500 mt-1"
+                                onClick={() => {
+                                  setOverrideCarpetPrice(false)
+                                  setTemplateForm({
+                                    ...templateForm,
+                                    carpetPrice: String(defaultCarpetPrice),
+                                  })
+                                }}
+                              >
+                                Use default
+                              </button>
+                            )}
+                          </div>
                         )}
                       </div>
                     )}
-                  </div>
+                  </>
                 )}
                 <div className="flex gap-2 justify-end">
                   <button className="px-3 py-2" onClick={() => { setShowNewTemplate(false); setEditing(false) }}>
@@ -1296,7 +1304,8 @@ const preserveTeamRef = useRef(false)
                 onClick={() => {
                   setSelectedOption(idx)
                   setSelectedEmployees([])
-                  resetCarpet(false)
+                  setCarpetEmployees([])
+                  setCarpetRate(null)
                 }}
               >
                 {o.sem} SEM / {o.com} COM - {o.hours}h


### PR DESCRIPTION
## Summary
- compute selected template info in CreateAppointmentModal
- hide carpet cleaning fields when the chosen template has no carpet rooms
- keep carpet room info when switching team option

## Testing
- `npm run build` in `client`
- `npm run build` in `server`


------
https://chatgpt.com/codex/tasks/task_e_68858bd5c118832d94198a490300e0bf