### PR TITLE
Update message with appointment type

### DIFF
--- a/client/src/Admin/pages/Calendar/components/DayTimeline.tsx
+++ b/client/src/Admin/pages/Calendar/components/DayTimeline.tsx
@@ -619,6 +619,14 @@ function Day({ appointments, nowOffset, scrollRef, animating, onUpdate, onCreate
                   onClick={(e) => e.stopPropagation()}
                 >
                   <div className="font-medium">Send Appointment Info</div>
+                  {selected && (
+                    <div className="text-sm space-y-1">
+                      <div>Appointment Date: {selected.date.slice(0, 10)}</div>
+                      <div>Appointment Time: {selected.time}</div>
+                      <div>Appointment Type: {selected.type}</div>
+                      <div>Address: {selected.address}</div>
+                    </div>
+                  )}
                   {selected?.employees && (
                     <ul className="pl-4 list-disc text-sm">
                       {selected.employees.map((e) => {

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1208,6 +1208,7 @@ app.post('/appointments/:id/send-info', async (req: Request, res: Response) => {
       const body = [
         `Appointment Date: ${appt.date.toISOString().slice(0, 10)}`,
         `Appointment Time: ${appt.time}`,
+        `Appointment Type: ${appt.type}`,
         `Address: ${appt.address}`,
         `Pay: $${(pay + (carpetIds.includes(e.id) ? carpetPer : 0)).toFixed(2)}`,
         appt.cityStateZip ? `Instructions: ${appt.cityStateZip}` : undefined,


### PR DESCRIPTION
## Summary
- add appointment type to SMS message body
- show appointment details in the Send Info modal
- build client and server to ensure compilation

## Testing
- `npm run build` in client
- `npm run build` in server

------
https://chatgpt.com/codex/tasks/task_e_6885bcd0fa4c832dbb7e1ff951e13d79