### PR TITLE
Add observation text for appointments

### DIFF
--- a/client/src/Admin/pages/Calendar/components/DayTimeline.tsx
+++ b/client/src/Admin/pages/Calendar/components/DayTimeline.tsx
@@ -63,6 +63,7 @@ function Day({ appointments, nowOffset, scrollRef, animating, onUpdate, onCreate
   const [tip, setTip] = useState('')
   const [showSendInfo, setShowSendInfo] = useState(false)
   const [note, setNote] = useState('')
+  const [observation, setObservation] = useState('')
 
   const updateAppointment = async (data: {
     status?: Appointment['status']
@@ -110,6 +111,7 @@ function Day({ appointments, nowOffset, scrollRef, animating, onUpdate, onCreate
         paymentMethodNote:
           paid && paymentMethod === 'OTHER' && otherPayment ? otherPayment : undefined,
         tip: paid ? parseFloat(tip) || 0 : 0,
+        observation: selected.observe ? observation : undefined,
       }),
     })
     if (res.ok) {
@@ -148,6 +150,7 @@ function Day({ appointments, nowOffset, scrollRef, animating, onUpdate, onCreate
     setPaymentMethod(selected.paymentMethod ?? '')
     setTip(selected.tip != null ? String(selected.tip) : '')
     setOtherPayment('')
+    setObservation(selected.observation ?? '')
   }, [selected])
 
   // Disable body scroll when modal is open
@@ -470,6 +473,17 @@ function Day({ appointments, nowOffset, scrollRef, animating, onUpdate, onCreate
                 </div>
               )}
             </div>
+
+            {selected.observe && (
+              <div className="space-y-1">
+                <label className="text-sm font-medium">Observation</label>
+                <textarea
+                  className="border p-2 rounded w-full text-base"
+                  value={observation}
+                  onChange={(e) => setObservation(e.target.value)}
+                />
+              </div>
+            )}
 
             <div className="flex flex-wrap justify-end gap-2 pt-2">
               <button className="px-4 py-1 bg-red-500 text-white rounded" onClick={() => setShowDelete(true)}>

--- a/client/src/Admin/pages/Calendar/types.ts
+++ b/client/src/Admin/pages/Calendar/types.ts
@@ -33,6 +33,7 @@ export interface Appointment {
   carpetPrice?: number
   reoccurring?: boolean
   observe?: boolean
+  observation?: string
   status?:
     | 'APPOINTED'
     | 'RESCHEDULE_NEW'

--- a/server/prisma/migrations/20250728030000_add_observation/migration.sql
+++ b/server/prisma/migrations/20250728030000_add_observation/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Appointment" ADD COLUMN "observation" TEXT;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -66,6 +66,7 @@ model Appointment {
   reoccurring     Boolean         @default(false)
   status          AppointmentStatus @default(APPOINTED)
   observe         Boolean         @default(false)
+  observation     String?
   lineage         String
   gateCode        String?
   doorCode        String?

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -830,6 +830,7 @@ app.post('/appointments', async (req: Request, res: Response) => {
       carpetPrice,
       carpetEmployees = [],
       status = 'APPOINTED',
+      observation,
     } = req.body as {
       clientId?: number
       templateId?: number
@@ -846,6 +847,7 @@ app.post('/appointments', async (req: Request, res: Response) => {
       carpetPrice?: number
       carpetEmployees?: number[]
       status?: string
+      observation?: string
     }
 
     // required-field guard
@@ -895,6 +897,7 @@ app.post('/appointments', async (req: Request, res: Response) => {
         notes:
           [template.notes, paymentMethodNote].filter(Boolean).join(' | ') ||
           undefined,
+        observation: observation ?? undefined,
         status: status as any,
         lineage: 'single',
         // only include the relation if there are IDs
@@ -938,6 +941,7 @@ app.put('/appointments/:id', async (req: Request, res: Response) => {
       carpetRooms,
       carpetPrice,
       carpetEmployees,
+      observation,
     } = req.body as {
       clientId?: number
       templateId?: number
@@ -955,6 +959,7 @@ app.put('/appointments/:id', async (req: Request, res: Response) => {
       carpetRooms?: number
       carpetPrice?: number
       carpetEmployees?: number[]
+      observation?: string | null
     }
     const data: any = {}
     if (clientId !== undefined) data.clientId = clientId
@@ -995,6 +1000,7 @@ app.put('/appointments/:id', async (req: Request, res: Response) => {
     if (paymentMethod !== undefined) data.paymentMethod = paymentMethod as any
     if (paymentMethodNote !== undefined) data.notes = paymentMethodNote
     if (tip !== undefined) data.tip = tip
+    if (observation !== undefined) data.observation = observation
     if (status !== undefined) data.status = status as any
     if (observe !== undefined) data.observe = observe
     if (carpetRooms !== undefined) data.carpetRooms = carpetRooms
@@ -1002,6 +1008,11 @@ app.put('/appointments/:id', async (req: Request, res: Response) => {
     if (carpetEmployees !== undefined) data.carpetEmployees = carpetEmployees
     if (employeeIds) {
       data.employees = { set: employeeIds.map((id) => ({ id })) }
+    }
+
+    if (observe === false ||
+        (status && ['CANCEL', 'RESCHEDULE_OLD', 'DELETED'].includes(status))) {
+      data.observation = null
     }
     const future = req.query.future === 'true'
     const current = await prisma.appointment.findUnique({ where: { id }, include: { employees: true, client: true } })


### PR DESCRIPTION
## Summary
- add optional `observation` column to `Appointment`
- support saving observation notes and clearing them when cancelling or unobserving appointments
- show observation textarea when an appointment is being observed

## Testing
- `npm test --prefix server` *(fails: Error: no test specified)*
- `npm run lint --prefix client` *(fails to satisfy lint rules)*

------
https://chatgpt.com/codex/tasks/task_e_6885c1b4dc40832d8e473ea41185c715