### PR TITLE
Add info sent tracking

### DIFF
--- a/client/src/Admin/pages/Calendar/components/DayTimeline.tsx
+++ b/client/src/Admin/pages/Calendar/components/DayTimeline.tsx
@@ -137,6 +137,9 @@ function Day({ appointments, nowOffset, scrollRef, animating, onUpdate, onCreate
       },
     )
     if (res.ok) {
+      const updated = (await res.json()) as Appointment
+      onUpdate?.(updated)
+      setSelected(updated)
       setShowSendInfo(false)
       setNote('')
     } else {
@@ -317,7 +320,15 @@ function Day({ appointments, nowOffset, scrollRef, animating, onUpdate, onCreate
                 setSelected(l.appt)
               }}
             >
-              {l.appt.type}
+              <div className="flex justify-between items-start p-1">
+                <div className="font-medium truncate pr-1">
+                  {l.appt.client?.name || 'Client'}
+                </div>
+                <div
+                  className={`w-3 h-3 rounded-sm ${l.appt.infoSent ? 'bg-green-500' : 'bg-red-500'}`}
+                />
+              </div>
+              <div className="px-1 pb-1">{l.appt.type}</div>
             </div>
           )
         })}

--- a/client/src/Admin/pages/Calendar/types.ts
+++ b/client/src/Admin/pages/Calendar/types.ts
@@ -34,6 +34,7 @@ export interface Appointment {
   reoccurring?: boolean
   observe?: boolean
   observation?: string
+  infoSent?: boolean
   status?:
     | 'APPOINTED'
     | 'RESCHEDULE_NEW'

--- a/server/prisma/migrations/20250728040000_add_info_sent/migration.sql
+++ b/server/prisma/migrations/20250728040000_add_info_sent/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Appointment" ADD COLUMN "infoSent" BOOLEAN NOT NULL DEFAULT false;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -67,6 +67,7 @@ model Appointment {
   status          AppointmentStatus @default(APPOINTED)
   observe         Boolean         @default(false)
   observation     String?
+  infoSent        Boolean         @default(false)
   lineage         String
   gateCode        String?
   doorCode        String?

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1235,7 +1235,13 @@ app.post('/appointments/:id/send-info', async (req: Request, res: Response) => {
       })
     }
 
-    res.json({ ok: true })
+    const updated = await prisma.appointment.update({
+      where: { id },
+      data: { infoSent: true },
+      include: { client: true, employees: true },
+    })
+
+    res.json(updated)
   } catch (err) {
     console.error('Failed to send appointment info:', err)
     res.status(500).json({ error: 'Failed to send info' })


### PR DESCRIPTION
## Summary
- add `infoSent` boolean to appointment schema with migration
- update send-info endpoint to mark appointments as sent
- display client name and sent status on calendar appointment blocks
- update React types and send-info handler

## Testing
- `npm --prefix client run build`
- `npm --prefix server run build`


------
https://chatgpt.com/codex/tasks/task_e_6885ca013ed0832d8abb57238f49f3b1