### PR TITLE
Shorter invoice identifier

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -203,7 +203,7 @@ async function generateInvoicePdf(inv: any): Promise<Buffer> {
     infoY -= 12
   })
 
-  const idDigits = BigInt('0x' + inv.id.replace(/-/g, '')).toString()
+  const idDigits = BigInt('0x' + inv.id.replace(/-/g, '')).toString().slice(-20)
   page.drawText('INVOICE', { x: width - margin - 120, y: y - 20, size: 26, font: bold, color: rgb(0.5, 0.7, 0.9) })
   page.drawText(`Date of issue: ${inv.createdAt.toISOString().slice(0, 10)}`, { x: width - margin - 200, y: y - 50, size: 10, font })
   page.drawText(`Invoice # ${idDigits}`, { x: width - margin - 200, y: y - 62, size: 10, font })


### PR DESCRIPTION
## Summary
- trim invoice id digits to 20 characters when generating PDFs

## Testing
- `npm --prefix server run build`

------
https://chatgpt.com/codex/tasks/task_e_6885dd1ebcc4832d8243c59854b929d0