### PR TITLE
Use modal alerts and improve invoice modal scrolling

### DIFF
--- a/client/src/Admin/pages/Calendar/components/CreateAppointmentModal.tsx
+++ b/client/src/Admin/pages/Calendar/components/CreateAppointmentModal.tsx
@@ -3,6 +3,7 @@ import { Client } from '../../Clients/components/types'
 import type { AppointmentTemplate } from '../types'
 import type { Employee } from '../../Employees/components/types'
 import { API_BASE_URL, fetchJson } from '../../../../api'
+import { useModal } from '../../../../ModalProvider'
 
 interface Props {
   onClose: () => void
@@ -28,6 +29,7 @@ const sizeOptions = [
 ]
 
 export default function CreateAppointmentModal({ onClose, onCreated, initialClientId, initialTemplateId, newStatus, initialAppointment }: Props) {
+  const { alert, confirm } = useModal()
   const persisted = (() => {
     const stored = localStorage.getItem('createAppointmentState')
     if (stored) {
@@ -510,7 +512,7 @@ const preserveTeamRef = useRef(false)
     if (!newClient.name.trim()) missing.push('name')
     if (!newClient.number.trim()) missing.push('number')
     if (missing.length > 0) {
-      alert('Please provide: ' + missing.join(', '))
+      await alert('Please provide: ' + missing.join(', '))
       return
     }
     const res = await fetch(`${API_BASE_URL}/clients`, {
@@ -526,7 +528,7 @@ const preserveTeamRef = useRef(false)
       setClientSearch('')
     } else {
       const err = await res.json().catch(() => ({}))
-      alert(err.error || 'Failed to create client')
+      await alert(err.error || 'Failed to create client')
     }
   }
 
@@ -577,7 +579,7 @@ const preserveTeamRef = useRef(false)
       }
     }
     if (missing.length > 0) {
-      alert('Please provide: ' + missing.join(', '))
+      await alert('Please provide: ' + missing.join(', '))
       return
     }
     const payload: any = {
@@ -629,7 +631,7 @@ const preserveTeamRef = useRef(false)
       setEditing(false)
       setEditingTemplateId(null)
     } else {
-      alert('Failed to create template')
+      await alert('Failed to create template')
     }
   }
 
@@ -655,25 +657,25 @@ const preserveTeamRef = useRef(false)
     if (!time) missing.push('time')
     if (!adminId) missing.push('admin')
     if (missing.length > 0) {
-      alert('Please provide: ' + missing.join(', '))
+      await alert('Please provide: ' + missing.join(', '))
       return
     }
     if (!isValidCarpet()) {
-      alert('Please complete carpet cleaning info')
+      await alert('Please complete carpet cleaning info')
       return
     }
     if (selectedEmployees.length < 1) {
-      alert('Team must have at least one member')
+      await alert('Team must have at least one member')
       return
     }
     if (!isValidSelection()) {
-      const proceed = confirm('Team is less than required. Continue?')
+      const proceed = await confirm('Team is less than required. Continue?')
       if (!proceed) return
     }
     if (time) {
       const hour = parseInt(time.split(':')[0], 10)
       if (hour < 6 || hour >= 18) {
-        const ok = confirm('Selected time is outside 6am-6pm. Continue?')
+        const ok = await confirm('Selected time is outside 6am-6pm. Continue?')
         if (!ok) return
       }
     }
@@ -722,7 +724,7 @@ const preserveTeamRef = useRef(false)
       method = 'PUT'
       const applyAll =
         initialAppointment.reoccurring &&
-        confirm('Apply changes to all future occurrences?')
+        (await confirm('Apply changes to all future occurrences?'))
       url = `${API_BASE_URL}/appointments/${initialAppointment.id}${applyAll ? '?future=true' : ''}`
     }
 
@@ -735,7 +737,7 @@ const preserveTeamRef = useRef(false)
       onCreated()
       handleCancel()
     } else {
-      alert('Failed to create appointment')
+      await alert('Failed to create appointment')
     }
   }
 

--- a/client/src/Admin/pages/Calendar/components/DayTimeline.tsx
+++ b/client/src/Admin/pages/Calendar/components/DayTimeline.tsx
@@ -8,6 +8,7 @@ import {
 import { createPortal } from 'react-dom'
 import type { Appointment } from '../types'
 import { API_BASE_URL } from '../../../../api'
+import { useModal } from '../../../../ModalProvider'
 
 function parseSqft(s: string | null | undefined): number | null {
   if (!s) return null
@@ -50,6 +51,7 @@ interface DayProps {
 }
 
 function Day({ appointments, nowOffset, scrollRef, animating, onUpdate, onCreate, onEdit }: DayProps) {
+  const { alert, confirm } = useModal()
   const [selected, setSelected] = useState<Appointment | null>(null)
   const [overlayTop, setOverlayTop] = useState(0)
   const [overlayHeight, setOverlayHeight] = useState(0)
@@ -72,7 +74,7 @@ function Day({ appointments, nowOffset, scrollRef, animating, onUpdate, onCreate
     if (!selected) return
     let url = `${API_BASE_URL}/appointments/${selected.id}`
     if (selected.reoccurring) {
-      const apply = confirm('Apply to all future occurrences?')
+      const apply = await confirm('Apply to all future occurrences?')
       if (apply) url += '?future=true'
     }
     const res = await fetch(url, {
@@ -88,7 +90,7 @@ function Day({ appointments, nowOffset, scrollRef, animating, onUpdate, onCreate
       onUpdate?.(updated)
       setSelected(null)
     } else {
-      alert('Failed to update appointment')
+      await alert('Failed to update appointment')
     }
   }
 
@@ -96,7 +98,7 @@ function Day({ appointments, nowOffset, scrollRef, animating, onUpdate, onCreate
     if (!selected) return
     let url = `${API_BASE_URL}/appointments/${selected.id}`
     if (selected.reoccurring) {
-      const apply = confirm('Apply to all future occurrences?')
+      const apply = await confirm('Apply to all future occurrences?')
       if (apply) url += '?future=true'
     }
     const res = await fetch(url, {
@@ -119,7 +121,7 @@ function Day({ appointments, nowOffset, scrollRef, animating, onUpdate, onCreate
       onUpdate?.(updated)
       setSelected(null)
     } else {
-      alert('Failed to update appointment')
+      await alert('Failed to update appointment')
     }
   }
 
@@ -143,7 +145,7 @@ function Day({ appointments, nowOffset, scrollRef, animating, onUpdate, onCreate
       setShowSendInfo(false)
       setNote('')
     } else {
-      alert('Failed to send info')
+      await alert('Failed to send info')
     }
   }
 

--- a/client/src/Admin/pages/Clients/components/ClientForm.tsx
+++ b/client/src/Admin/pages/Clients/components/ClientForm.tsx
@@ -1,10 +1,12 @@
 import { useEffect, useState } from 'react'
+import { useModal } from '../../../../ModalProvider'
 import useFormPersistence, { clearFormPersistence, loadFormPersistence } from "../../../../useFormPersistence"
 import { useNavigate, useParams } from 'react-router-dom'
 import { Client } from './types'
 import { API_BASE_URL, fetchJson } from '../../../../api'
 
 export default function ClientForm() {
+  const { alert } = useModal()
   const { id } = useParams()
   const navigate = useNavigate()
   const isNew = id === undefined
@@ -55,7 +57,7 @@ export default function ClientForm() {
     })
     if (!res.ok) {
       const err = await res.json().catch(() => ({}))
-      alert(err.error || 'Failed to save')
+      await alert(err.error || 'Failed to save')
       return
     }
     clearFormPersistence(storageKey)

--- a/client/src/Admin/pages/Employees/components/EmployeeForm.tsx
+++ b/client/src/Admin/pages/Employees/components/EmployeeForm.tsx
@@ -1,10 +1,12 @@
 import { useEffect, useState } from 'react'
+import { useModal } from '../../../../ModalProvider'
 import { useNavigate, useParams } from 'react-router-dom'
 import { Employee } from './types'
 import { API_BASE_URL, fetchJson } from '../../../../api'
 import useFormPersistence, { clearFormPersistence, loadFormPersistence } from '../../../../useFormPersistence'
 
 export default function EmployeeForm() {
+  const { alert } = useModal()
   const { id } = useParams()
   const navigate = useNavigate()
   const isNew = id === undefined
@@ -71,7 +73,7 @@ export default function EmployeeForm() {
     })
     if (!res.ok) {
       const err = await res.json().catch(() => ({}))
-      alert(err.error || 'Failed to save')
+      await alert(err.error || 'Failed to save')
       return
     }
     clearFormPersistence(storageKey)

--- a/client/src/Admin/pages/Financing/components/CreateInvoiceModal.tsx
+++ b/client/src/Admin/pages/Financing/components/CreateInvoiceModal.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import type { Appointment } from '../../Calendar/types'
 import { API_BASE_URL } from '../../../../api'
+import { useModal } from '../../../../ModalProvider'
 
 interface Props {
   appointment: Appointment
@@ -8,6 +9,7 @@ interface Props {
 }
 
 export default function CreateInvoiceModal({ appointment, onClose }: Props) {
+  const { alert } = useModal()
   const [clientName, setClientName] = useState(appointment.client?.name || '')
   const [billedTo, setBilledTo] = useState(appointment.client?.name || '')
   const [address, setAddress] = useState(appointment.address)
@@ -40,6 +42,14 @@ export default function CreateInvoiceModal({ appointment, onClose }: Props) {
         .catch(() => {})
     }
   }, [appointment])
+
+  useEffect(() => {
+    const original = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => {
+      document.body.style.overflow = original
+    }
+  }, [])
 
   const subtotal =
     (parseFloat(price) || 0) +
@@ -79,7 +89,7 @@ export default function CreateInvoiceModal({ appointment, onClose }: Props) {
       onClose()
     } else {
       if (newWindow) newWindow.close()
-      alert('Failed to create invoice')
+      await alert('Failed to create invoice')
     }
   }
 
@@ -122,13 +132,16 @@ export default function CreateInvoiceModal({ appointment, onClose }: Props) {
       onClose()
     } else {
       if (newWindow) newWindow.close()
-      alert('Failed to create invoice')
+      await alert('Failed to create invoice')
     }
   }
 
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-2 z-30" onClick={onClose}>
-      <div className="bg-white p-4 rounded w-full max-w-md space-y-3" onClick={(e) => e.stopPropagation()}>
+      <div
+        className="bg-white p-4 rounded w-full max-w-md space-y-3 max-h-[calc(100vh-1rem)] overflow-y-auto"
+        onClick={(e) => e.stopPropagation()}
+      >
         <div className="flex justify-between items-center">
           <h2 className="text-lg font-semibold">Create Invoice</h2>
           <button onClick={onClose}>X</button>

--- a/client/src/ModalProvider.tsx
+++ b/client/src/ModalProvider.tsx
@@ -1,0 +1,79 @@
+import { createContext, useContext, useState, ReactNode } from 'react'
+import { createPortal } from 'react-dom'
+
+interface ModalContextProps {
+  alert: (message: string) => Promise<void>
+  confirm: (message: string) => Promise<boolean>
+}
+
+interface ModalState {
+  type: 'alert' | 'confirm'
+  message: string
+  resolve: (value: any) => void
+}
+
+const ModalContext = createContext<ModalContextProps | null>(null)
+
+export function ModalProvider({ children }: { children: ReactNode }) {
+  const [modal, setModal] = useState<ModalState | null>(null)
+
+  const alert = (message: string) =>
+    new Promise<void>((resolve) => setModal({ type: 'alert', message, resolve }))
+
+  const confirm = (message: string) =>
+    new Promise<boolean>((resolve) => setModal({ type: 'confirm', message, resolve }))
+
+  const close = (result: any) => {
+    modal?.resolve(result)
+    setModal(null)
+  }
+
+  return (
+    <ModalContext.Provider value={{ alert, confirm }}>
+      {children}
+      {modal &&
+        createPortal(
+          <div
+            className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50"
+            onClick={() => close(modal.type === 'confirm' ? false : undefined)}
+          >
+            <div
+              className="bg-white p-4 rounded max-w-sm w-full"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <p className="mb-4 whitespace-pre-line">{modal.message}</p>
+              {modal.type === 'alert' ? (
+                <div className="text-right">
+                  <button
+                    className="px-4 py-1 bg-blue-500 text-white rounded"
+                    onClick={() => close(undefined)}
+                  >
+                    OK
+                  </button>
+                </div>
+              ) : (
+                <div className="flex justify-end gap-2">
+                  <button className="px-4 py-1" onClick={() => close(false)}>
+                    Cancel
+                  </button>
+                  <button
+                    className="px-4 py-1 bg-blue-500 text-white rounded"
+                    onClick={() => close(true)}
+                  >
+                    OK
+                  </button>
+                </div>
+              )}
+            </div>
+          </div>,
+          document.body,
+        )}
+    </ModalContext.Provider>
+  )
+}
+
+export function useModal() {
+  const ctx = useContext(ModalContext)
+  if (!ctx) throw new Error('useModal must be inside ModalProvider')
+  return ctx
+}

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -3,11 +3,14 @@ import { createRoot } from 'react-dom/client'
 import { GoogleOAuthProvider } from '@react-oauth/google'
 import './index.css'
 import App from './App'
+import { ModalProvider } from './ModalProvider'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <GoogleOAuthProvider clientId={import.meta.env.VITE_GOOGLE_CLIENT_ID}>
-      <App />
+      <ModalProvider>
+        <App />
+      </ModalProvider>
     </GoogleOAuthProvider>
   </StrictMode>,
 )


### PR DESCRIPTION
## Summary
- add ModalProvider with `alert` and `confirm` helpers
- wrap the app in ModalProvider
- convert all alert/confirm calls to use modal dialogs
- disable body scroll when invoice modal is open and allow scrolling within the modal

## Testing
- `npm run lint` *(fails: `Fast refresh only works when a file only exports components` and many other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_688728db5b08832db354b93ec7808338