### PR TITLE
Fix invoice modal safe area for iOS

### DIFF
--- a/client/src/Admin/pages/Financing/components/CreateInvoiceModal.tsx
+++ b/client/src/Admin/pages/Financing/components/CreateInvoiceModal.tsx
@@ -137,9 +137,12 @@ export default function CreateInvoiceModal({ appointment, onClose }: Props) {
   }
 
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-2 z-30" onClick={onClose}>
+    <div
+      className="fixed inset-0 bg-black/50 flex items-center justify-center p-2 z-30 modal-safe-area"
+      onClick={onClose}
+    >
       <div
-        className="bg-white p-4 rounded w-full max-w-md space-y-3 max-h-[calc(100vh-1rem)] overflow-y-auto"
+        className="bg-white p-4 rounded w-full max-w-md space-y-3 max-h-[calc(100dvh-1rem)] overflow-y-auto"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex justify-between items-center">

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,3 +1,9 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/* Ensure modals are not obscured by iOS safe areas */
+.modal-safe-area {
+  padding-top: max(env(safe-area-inset-top), 0.5rem);
+  padding-bottom: max(env(safe-area-inset-bottom), 0.5rem);
+}


### PR DESCRIPTION
## Summary
- ensure modals use padding for iOS safe area
- adjust invoice modal to respect device safe areas

## Testing
- `npm run lint` *(fails: cannot pass existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68872c104144832da6e8b7f24dae2bf5