### PR TITLE
Add disable flag for clients and employees

### DIFF
--- a/client/src/Admin/pages/Clients/components/ClientForm.tsx
+++ b/client/src/Admin/pages/Clients/components/ClientForm.tsx
@@ -12,7 +12,7 @@ export default function ClientForm() {
   const isNew = id === undefined
   const storageKey = `clientForm-${id || 'new'}`
   const [data, setData] = useState<Client>(() =>
-    loadFormPersistence(storageKey, { name: '', number: '', notes: '' }),
+    loadFormPersistence(storageKey, { name: '', number: '', notes: '', disabled: false }),
   )
   useFormPersistence(storageKey, data)
 
@@ -47,9 +47,20 @@ export default function ClientForm() {
     setData(updated)
   }
 
+  const handleCheckboxChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const updated = { ...data, [e.target.name]: e.target.checked }
+    persist(updated)
+    setData(updated)
+  }
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
-    const payload = { name: data.name, number: data.number, notes: data.notes }
+    const payload = {
+      name: data.name,
+      number: data.number,
+      notes: data.notes,
+      disabled: data.disabled ?? false,
+    }
     const res = await fetch(`${API_BASE_URL}/clients${isNew ? '' : '/' + id}`, {
       method: isNew ? 'POST' : 'PUT',
       headers: { 'Content-Type': 'application/json', "ngrok-skip-browser-warning": "1" },
@@ -103,6 +114,16 @@ export default function ClientForm() {
           onChange={handleChange}
           className="w-full border p-2 rounded"
         />
+      </div>
+      <div className="flex items-center gap-2">
+        <input
+          id="disabled"
+          name="disabled"
+          type="checkbox"
+          checked={data.disabled ?? false}
+          onChange={handleCheckboxChange}
+        />
+        <label htmlFor="disabled" className="text-sm">Disable</label>
       </div>
       <button className="bg-blue-500 text-white px-4 py-2 rounded" type="submit">
         Save

--- a/client/src/Admin/pages/Clients/components/ClientList.tsx
+++ b/client/src/Admin/pages/Clients/components/ClientList.tsx
@@ -21,7 +21,11 @@ export default function ClientList() {
   }, [page, search])
 
   function load() {
-    fetchJson(`${API_BASE_URL}/clients?search=${encodeURIComponent(search)}&skip=${page * 20}&take=20`)
+    fetchJson(
+      `${API_BASE_URL}/clients?search=${encodeURIComponent(search)}&skip=${
+        page * 20
+      }&take=20&all=true`,
+    )
       .then((data: Client[]) => {
         setItems((prev) => {
           const next = page === 0 ? data : [...prev, ...data]

--- a/client/src/Admin/pages/Clients/components/types.ts
+++ b/client/src/Admin/pages/Clients/components/types.ts
@@ -3,4 +3,5 @@ export interface Client {
   name: string
   number: string
   notes?: string
+  disabled?: boolean
 }

--- a/client/src/Admin/pages/Employees/components/EmployeeForm.tsx
+++ b/client/src/Admin/pages/Employees/components/EmployeeForm.tsx
@@ -17,6 +17,7 @@ export default function EmployeeForm() {
       number: '',
       notes: '',
       experienced: false,
+      disabled: false,
     }),
   )
   useFormPersistence(storageKey, data)
@@ -24,7 +25,7 @@ export default function EmployeeForm() {
   useEffect(() => {
     if (!isNew) {
       fetchJson(`${API_BASE_URL}/employees/${id}`)
-        .then((d) => setData({ experienced: false, ...d }))
+        .then((d) => setData({ experienced: false, disabled: false, ...d }))
         .catch((err) => console.error(err))
     }
   }, [id, isNew])
@@ -45,7 +46,7 @@ export default function EmployeeForm() {
   }
 
   const handleCheckboxChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const updated = { ...data, experienced: e.target.checked }
+    const updated = { ...data, [e.target.name]: e.target.checked }
     persist(updated)
     setData(updated)
   }
@@ -65,6 +66,7 @@ export default function EmployeeForm() {
       number: data.number,
       notes: data.notes,
       experienced: data.experienced,
+      disabled: data.disabled ?? false,
     }
     const res = await fetch(`${API_BASE_URL}/employees${isNew ? '' : '/' + id}` ,{
       method: isNew ? 'POST' : 'PUT',
@@ -123,11 +125,22 @@ export default function EmployeeForm() {
       <div className="flex items-center gap-2">
         <input
           id="experienced"
+          name="experienced"
           type="checkbox"
           checked={data.experienced ?? false}
           onChange={handleCheckboxChange}
         />
         <label htmlFor="experienced" className="text-sm">Experienced</label>
+      </div>
+      <div className="flex items-center gap-2">
+        <input
+          id="disabled"
+          name="disabled"
+          type="checkbox"
+          checked={data.disabled ?? false}
+          onChange={handleCheckboxChange}
+        />
+        <label htmlFor="disabled" className="text-sm">Disable</label>
       </div>
       <div className="flex gap-2">
         <button className="bg-blue-500 text-white px-4 py-2 rounded" type="submit">

--- a/client/src/Admin/pages/Employees/components/EmployeeList.tsx
+++ b/client/src/Admin/pages/Employees/components/EmployeeList.tsx
@@ -23,7 +23,11 @@ export default function EmployeeList(_: EmployeeListProps) {
   }, [page, search])
 
   function load() {
-    fetchJson(`${API_BASE_URL}/employees?search=${encodeURIComponent(search)}&skip=${page * 20}&take=20`)
+    fetchJson(
+      `${API_BASE_URL}/employees?search=${encodeURIComponent(search)}&skip=${
+        page * 20
+      }&take=20&all=true`,
+    )
       .then((data: Employee[]) => {
         setItems((prev) => {
           const next = page === 0 ? data : [...prev, ...data]

--- a/client/src/Admin/pages/Employees/components/types.ts
+++ b/client/src/Admin/pages/Employees/components/types.ts
@@ -4,4 +4,5 @@ export interface Employee {
   number: string
   notes?: string
   experienced?: boolean
+  disabled?: boolean
 }

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -22,6 +22,7 @@ model Client {
   name                 String                 @unique
   number               String
   notes                String?
+  disabled             Boolean                @default(false)
   appointments         Appointment[]
   appointmentTemplates AppointmentTemplate[]
 }
@@ -32,6 +33,7 @@ model Employee {
   number       String
   notes        String?
   experienced  Boolean                    @default(false)
+  disabled     Boolean                    @default(false)
   appointments Appointment[]              @relation("AppointmentEmployees")
 
   prevBalance  Float                      @default(0)


### PR DESCRIPTION
## Summary
- allow disabling clients and employees
- update API to filter disabled entries unless `all=true`
- support `disabled` in Prisma schema
- show disabled clients and employees on list pages
- add disable checkbox to client and employee forms

## Testing
- `npm run build` in `client`
- `npm run build` in `server`


------
https://chatgpt.com/codex/tasks/task_e_688852b7a854832db94321dc2e4b171b