### PR TITLE
Allow creating no-team appointments

### DIFF
--- a/client/src/Admin/pages/Calendar/components/CreateAppointmentModal.tsx
+++ b/client/src/Admin/pages/Calendar/components/CreateAppointmentModal.tsx
@@ -127,6 +127,7 @@ export default function CreateAppointmentModal({ onClose, onCreated, initialClie
   const [overrideCarpetPrice, setOverrideCarpetPrice] = useState<boolean>(
     persisted.overrideCarpetPrice ?? false,
   )
+  const [noTeam, setNoTeam] = useState<boolean>(persisted.noTeam ?? false)
 
   const selectedTemplateData = selectedTemplate
     ? templates.find((tt) => tt.id === selectedTemplate)
@@ -191,6 +192,7 @@ const preserveTeamRef = useRef(false)
         setCarpetRooms(String((initialAppointment as any).carpetRooms))
       }
       if (initialAppointment.reoccurring) setRecurringEnabled(true)
+      if (initialAppointment.noTeam) setNoTeam(true)
       initializedRef.current = true
       localStorage.removeItem('createAppointmentState')
     } else {
@@ -229,6 +231,7 @@ const preserveTeamRef = useRef(false)
           if (typeof s.recurringEnabled === 'boolean') setRecurringEnabled(s.recurringEnabled)
           if (s.recurringOption) setRecurringOption(s.recurringOption)
           if (s.recurringMonths) setRecurringMonths(s.recurringMonths)
+          if (typeof s.noTeam === 'boolean') setNoTeam(s.noTeam)
         } catch {}
       }
       initializedRef.current = true
@@ -266,9 +269,10 @@ const preserveTeamRef = useRef(false)
       recurringEnabled,
       recurringOption,
       recurringMonths,
+      noTeam,
     }
     localStorage.setItem('createAppointmentState', JSON.stringify(data))
-  }, [clientSearch, selectedClient, newClient, showNewClient, selectedTemplate, showNewTemplate, editing, editingTemplateId, templateForm, date, time, adminId, paid, tip, paymentMethod, otherPayment, showTeamModal, employeeSearch, selectedEmployees, selectedOption, carpetEnabled, carpetRooms, templateForm.carpetPrice, overrideCarpetPrice, carpetEmployees, recurringEnabled, recurringOption, recurringMonths])
+  }, [clientSearch, selectedClient, newClient, showNewClient, selectedTemplate, showNewTemplate, editing, editingTemplateId, templateForm, date, time, adminId, paid, tip, paymentMethod, otherPayment, showTeamModal, employeeSearch, selectedEmployees, selectedOption, carpetEnabled, carpetRooms, templateForm.carpetPrice, overrideCarpetPrice, carpetEmployees, recurringEnabled, recurringOption, recurringMonths, noTeam])
 
   useEffect(() => {
     if (selectedTemplate !== null) {
@@ -664,7 +668,7 @@ const preserveTeamRef = useRef(false)
       await alert('Please complete carpet cleaning info')
       return
     }
-    if (selectedEmployees.length < 1) {
+    if (!noTeam && selectedEmployees.length < 1) {
       await alert('Team must have at least one member')
       return
     }
@@ -685,7 +689,7 @@ const preserveTeamRef = useRef(false)
       date,
       time,
       hours: staffOptions[selectedOption]?.hours,
-      employeeIds: selectedEmployees,
+      employeeIds: noTeam ? [] : selectedEmployees,
       adminId: adminId || undefined,
       paid,
       paymentMethod: paid ? (paymentMethod || 'CASH') : 'CASH',
@@ -693,6 +697,7 @@ const preserveTeamRef = useRef(false)
         paid && paymentMethod === 'OTHER' && otherPayment ? otherPayment : undefined,
       tip: paid ? parseFloat(tip) || 0 : 0,
       status: recurringEnabled ? 'REOCCURRING' : newStatus ?? 'APPOINTED',
+      noTeam,
       ...(carpetEnabled
         ? {
             carpetRooms: parseInt(carpetRooms, 10) || 0,
@@ -1064,12 +1069,32 @@ const preserveTeamRef = useRef(false)
         {/* Team selection */}
         {selectedTemplate && staffOptions.length > 0 && (
           <div className="space-y-1">
-            <button
-              className="border px-3 py-2 rounded"
-              onClick={() => setShowTeamModal(true)}
-            >
-              Team Options <span className="text-red-500">*</span>
-            </button>
+            <label className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={noTeam}
+                onChange={async (e) => {
+                  if (e.target.checked) {
+                    const ok = await confirm('Create appointment with no team?')
+                    if (!ok) return
+                  }
+                  setNoTeam(e.target.checked)
+                  if (e.target.checked) {
+                    setSelectedEmployees([])
+                    setCarpetEmployees([])
+                  }
+                }}
+              />
+              <span>No Team</span>
+            </label>
+            {!noTeam && (
+              <>
+                <button
+                  className="border px-3 py-2 rounded"
+                  onClick={() => setShowTeamModal(true)}
+                >
+                  Team Options <span className="text-red-500">*</span>
+                </button>
             {selectedEmployees.length > 0 && staffOptions[selectedOption] && (
               <>
                 <div className="text-sm border rounded p-2 space-y-1">
@@ -1119,7 +1144,7 @@ const preserveTeamRef = useRef(false)
         )}
 
         {/* Recurring */}
-        {selectedTemplate && selectedEmployees.length > 0 && (
+        {selectedTemplate && (selectedEmployees.length > 0 || noTeam) && (
           <div className="space-y-1">
             <label className="flex items-center gap-2">
               <span>Recurring</span>

--- a/client/src/Admin/pages/Calendar/types.ts
+++ b/client/src/Admin/pages/Calendar/types.ts
@@ -29,6 +29,7 @@ export interface Appointment {
   paid?: boolean
   paymentMethod?: 'CASH' | 'ZELLE' | 'VENMO' | 'PAYPAL' | 'OTHER' | 'CHECK'
   tip?: number
+  noTeam?: boolean
   carpetRooms?: number
   carpetPrice?: number
   reoccurring?: boolean

--- a/server/prisma/migrations/20250728050000_add_no_team/migration.sql
+++ b/server/prisma/migrations/20250728050000_add_no_team/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Appointment" ADD COLUMN "noTeam" BOOLEAN NOT NULL DEFAULT false;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -62,6 +62,7 @@ model Appointment {
   paid            Boolean         @default(false)
   paymentMethod   PaymentMethod
   tip             Float           @default(0)
+  noTeam          Boolean         @default(false)
   carpetRooms     Int?
   carpetPrice     Float?
   carpetEmployees Int[]

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -795,6 +795,7 @@ app.post('/appointments/recurring', async (req: Request, res: Response) => {
       carpetEmployees = [],
       count = 1,
       frequency,
+      noTeam = false,
     } = req.body as {
       clientId?: number
       templateId?: number
@@ -812,6 +813,7 @@ app.post('/appointments/recurring', async (req: Request, res: Response) => {
       carpetEmployees?: number[]
       count?: number
       frequency?: string
+      noTeam?: boolean
     }
 
     if (!clientId || !templateId || !date || !time || !adminId || !frequency) {
@@ -866,9 +868,10 @@ app.post('/appointments/recurring', async (req: Request, res: Response) => {
           price: template.price,
           paid,
           tip,
+          noTeam,
           carpetRooms: carpetRoomsFinal,
           carpetPrice: finalCarpetPrice ?? null,
-        carpetEmployees,
+          carpetEmployees,
           paymentMethod: paymentMethod as any,
           notes:
             [template.notes, paymentMethodNote].filter(Boolean).join(' | ') ||
@@ -883,7 +886,7 @@ app.post('/appointments/recurring', async (req: Request, res: Response) => {
           }),
         },
       })
-      if (employeeIds.length) {
+      if (!noTeam && employeeIds.length) {
         await syncPayrollItems(appt.id, employeeIds)
       }
       created.push(appt)
@@ -915,6 +918,7 @@ app.post('/appointments', async (req: Request, res: Response) => {
       carpetEmployees = [],
       status = 'APPOINTED',
       observation,
+      noTeam = false,
     } = req.body as {
       clientId?: number
       templateId?: number
@@ -932,6 +936,7 @@ app.post('/appointments', async (req: Request, res: Response) => {
       carpetEmployees?: number[]
       status?: string
       observation?: string
+      noTeam?: boolean
     }
 
     // required-field guard
@@ -974,6 +979,7 @@ app.post('/appointments', async (req: Request, res: Response) => {
         price: template.price,
         paid,
         tip,
+        noTeam,
         carpetRooms: carpetRoomsFinal,
         carpetPrice: finalCarpetPrice ?? null,
         carpetEmployees,
@@ -993,7 +999,7 @@ app.post('/appointments', async (req: Request, res: Response) => {
       },
     })
 
-    if (employeeIds.length) {
+    if (!noTeam && employeeIds.length) {
       await syncPayrollItems(appt.id, employeeIds)
     }
 
@@ -1026,6 +1032,7 @@ app.put('/appointments/:id', async (req: Request, res: Response) => {
       carpetPrice,
       carpetEmployees,
       observation,
+      noTeam = false,
     } = req.body as {
       clientId?: number
       templateId?: number
@@ -1044,6 +1051,7 @@ app.put('/appointments/:id', async (req: Request, res: Response) => {
       carpetPrice?: number
       carpetEmployees?: number[]
       observation?: string | null
+      noTeam?: boolean
     }
     const data: any = {}
     if (clientId !== undefined) data.clientId = clientId
@@ -1084,6 +1092,7 @@ app.put('/appointments/:id', async (req: Request, res: Response) => {
     if (paymentMethod !== undefined) data.paymentMethod = paymentMethod as any
     if (paymentMethodNote !== undefined) data.notes = paymentMethodNote
     if (tip !== undefined) data.tip = tip
+    if (noTeam !== undefined) data.noTeam = noTeam
     if (observation !== undefined) data.observation = observation
     if (status !== undefined) data.status = status as any
     if (observe !== undefined) data.observe = observe
@@ -1138,6 +1147,7 @@ app.put('/appointments/:id', async (req: Request, res: Response) => {
             price: last.price ?? null,
             paid: last.paid,
             tip: last.tip,
+            noTeam: last.noTeam,
             carpetRooms: last.carpetRooms ?? null,
             carpetPrice: last.carpetPrice ?? null,
             carpetEmployees: last.carpetEmployees ?? [],
@@ -1227,6 +1237,7 @@ app.put('/appointments/:id', async (req: Request, res: Response) => {
                 price: last.price ?? null,
                 paid: last.paid,
                 tip: last.tip,
+                noTeam: last.noTeam,
                 carpetRooms: last.carpetRooms ?? null,
                 carpetPrice: last.carpetPrice ?? null,
                 carpetEmployees: last.carpetEmployees ?? [],
@@ -1270,7 +1281,7 @@ app.put('/appointments/:id', async (req: Request, res: Response) => {
         data,
         include: { client: true, employees: true },
       })
-      if (employeeIds) {
+      if (employeeIds && !noTeam) {
         await syncPayrollItems(appt.id, employeeIds)
       }
       res.json(appt)


### PR DESCRIPTION
## Summary
- support `noTeam` flag in Prisma schema
- migrate database with new `noTeam` column
- accept `noTeam` in appointment API routes
- add `noTeam` field to appointment types
- surface a "No Team" checkbox in the appointment modal

## Testing
- `npm run lint` *(fails: 79 problems)*
- `npm run build` in server

------
https://chatgpt.com/codex/tasks/task_e_6888600fc224832da752d20f1f602bf6