### PR TITLE
Fix No Team checkbox interaction

### DIFF
--- a/client/src/Admin/pages/Calendar/components/CreateAppointmentModal.tsx
+++ b/client/src/Admin/pages/Calendar/components/CreateAppointmentModal.tsx
@@ -1074,12 +1074,13 @@ const preserveTeamRef = useRef(false)
                 type="checkbox"
                 checked={noTeam}
                 onChange={async (e) => {
-                  if (e.target.checked) {
+                  const checked = e.target.checked
+                  if (checked) {
                     const ok = await confirm('Create appointment with no team?')
                     if (!ok) return
                   }
-                  setNoTeam(e.target.checked)
-                  if (e.target.checked) {
+                  setNoTeam(checked)
+                  if (checked) {
                     setSelectedEmployees([])
                     setCarpetEmployees([])
                   }


### PR DESCRIPTION
## Summary
- ensure the `No Team` checkbox keeps its state after confirmation
- hide the Team Options button once `No Team` is checked

## Testing
- `npm test` (fails: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_688870d335cc832d8b87965b011549b7