### PR TITLE
Add home panel for no-team appointments

### DIFF
--- a/client/src/Admin/pages/Home/HomePanel.tsx
+++ b/client/src/Admin/pages/Home/HomePanel.tsx
@@ -1,0 +1,37 @@
+import React from 'react'
+
+export interface HomePanelCard {
+  key: React.Key
+  content: React.ReactNode
+  actionLabel?: string
+  onAction?: () => void
+}
+
+interface Props {
+  title: string
+  cards: HomePanelCard[]
+  className?: string
+}
+
+export default function HomePanel({ title, cards, className = '' }: Props) {
+  return (
+    <div className={`bg-white rounded shadow flex flex-col ${className}`}>
+      <div className="p-3 font-medium border-b">{title}</div>
+      <ul className="divide-y overflow-y-auto">
+        {cards.map((c) => (
+          <li key={c.key} className="p-3 flex justify-between items-center">
+            <div>{c.content}</div>
+            {c.onAction && (
+              <button
+                className="text-blue-500 text-sm"
+                onClick={c.onAction}
+              >
+                {c.actionLabel || 'View'}
+              </button>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/client/src/Admin/pages/Home/index.tsx
+++ b/client/src/Admin/pages/Home/index.tsx
@@ -1,10 +1,83 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
+import { API_BASE_URL, fetchJson } from '../../../api'
+import type { Appointment } from '../Calendar/types'
+import CreateAppointmentModal from '../Calendar/components/CreateAppointmentModal'
+import HomePanel, { HomePanelCard } from './HomePanel'
 
 export default function Home() {
+  const [items, setItems] = useState<Appointment[]>([])
+  const [editParams, setEditParams] = useState<{
+    clientId?: number
+    templateId?: number | null
+    status?: Appointment['status']
+    appointment?: Appointment
+  } | null>(null)
+
+  const load = () => {
+    fetchJson(`${API_BASE_URL}/appointments/no-team`)
+      .then((d) => setItems(d))
+      .catch(() => setItems([]))
+  }
+
+  useEffect(() => {
+    load()
+  }, [])
+
+  const handleEdit = async (appt: Appointment) => {
+    localStorage.removeItem('createAppointmentState')
+    try {
+      const templates = await fetchJson(
+        `${API_BASE_URL}/appointment-templates?clientId=${appt.clientId}`,
+      )
+      const match = templates.find(
+        (t: any) => t.address === appt.address && t.type === appt.type && t.size === appt.size,
+      )
+      setEditParams({
+        clientId: appt.clientId,
+        templateId: match?.id ?? null,
+        status: appt.status,
+        appointment: appt,
+      })
+    } catch {
+      setEditParams({ clientId: appt.clientId, status: appt.status, appointment: appt })
+    }
+  }
+
+  const formatTime = (t: string) => {
+    const [h, m] = t.split(':').map(Number)
+    const ampm = h >= 12 ? 'PM' : 'AM'
+    const hh = ((h + 11) % 12) + 1
+    return `${hh}:${m.toString().padStart(2, '0')} ${ampm}`
+  }
+
+  const cards: HomePanelCard[] = items.map((a) => ({
+    key: a.id!,
+    content: (
+      <div>
+        <div className="font-medium">{a.client?.name}</div>
+        <div className="text-sm text-gray-600">
+          {a.date.slice(0, 10)} {formatTime(a.time)}
+        </div>
+      </div>
+    ),
+    actionLabel: 'View',
+    onAction: () => handleEdit(a),
+  }))
+
   return (
-    <div className="p-4">
+    <div className="p-4 space-y-4">
       <h2 className="text-xl font-semibold">Home</h2>
-      <p>Welcome to the admin dashboard.</p>
+      <HomePanel title="Appointments with no teams" cards={cards} />
+      {editParams && (
+        <CreateAppointmentModal
+          onClose={() => setEditParams(null)}
+          onCreated={load}
+          initialClientId={editParams.clientId}
+          initialTemplateId={editParams.templateId ?? undefined}
+          newStatus={editParams.status}
+          initialAppointment={editParams.appointment}
+        />
+      )}
     </div>
   )
 }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -776,6 +776,26 @@ app.get('/appointments/lineage/:lineage', async (req: Request, res: Response) =>
   }
 })
 
+app.get('/appointments/no-team', async (_req: Request, res: Response) => {
+  try {
+    const today = new Date()
+    today.setHours(0, 0, 0, 0)
+    const appts = await prisma.appointment.findMany({
+      where: {
+        noTeam: true,
+        status: { notIn: ['DELETED', 'RESCHEDULE_OLD', 'CANCEL'] },
+        date: { gte: today },
+      },
+      orderBy: [{ date: 'asc' }, { time: 'asc' }],
+      include: { client: true, employees: true },
+    })
+    res.json(appts)
+  } catch (err) {
+    console.error('Failed to fetch no-team appointments:', err)
+    res.status(500).json({ error: 'Failed to fetch appointments' })
+  }
+})
+
 app.post('/appointments/recurring', async (req: Request, res: Response) => {
   try {
     const {


### PR DESCRIPTION
## Summary
- create `HomePanel` component for home page sections
- list upcoming appointments with no team
- allow opening existing appointment in edit modal
- expose `/appointments/no-team` endpoint on server

## Testing
- `npm run lint` *(fails: many lint errors in repo)*
- `npm run build` in server

------
https://chatgpt.com/codex/tasks/task_e_68894917a6d8832da9d8cdf6a592f33c