### PR TITLE
Add fixed height scrollable area for home panel

### DIFF
--- a/client/src/Admin/pages/Home/HomePanel.tsx
+++ b/client/src/Admin/pages/Home/HomePanel.tsx
@@ -17,21 +17,26 @@ export default function HomePanel({ title, cards, className = '' }: Props) {
   return (
     <div className={`bg-white rounded shadow flex flex-col ${className}`}>
       <div className="p-3 font-medium border-b">{title}</div>
-      <ul className="divide-y overflow-y-auto">
-        {cards.map((c) => (
-          <li key={c.key} className="p-3 flex justify-between items-center">
-            <div>{c.content}</div>
-            {c.onAction && (
-              <button
-                className="text-blue-500 text-sm"
-                onClick={c.onAction}
-              >
-                {c.actionLabel || 'View'}
-              </button>
-            )}
-          </li>
-        ))}
-      </ul>
+      <div
+        className="bg-gray-50 overflow-y-auto"
+        style={{ maxHeight: '20rem', minHeight: '20rem' }}
+      >
+        <ul className="divide-y">
+          {cards.map((c) => (
+            <li key={c.key} className="p-3 flex justify-between items-center">
+              <div>{c.content}</div>
+              {c.onAction && (
+                <button
+                  className="text-blue-500 text-sm"
+                  onClick={c.onAction}
+                >
+                  {c.actionLabel || 'View'}
+                </button>
+              )}
+            </li>
+          ))}
+        </ul>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- give `HomePanel` a fixed-height body so five cards fit with scrolling

## Testing
- `npm run lint` *(fails: process not defined and other lints)*

------
https://chatgpt.com/codex/tasks/task_e_68897dabcbac832dadde8ce1dc8da1d6