### PR TITLE
Add done checkbox for recurring panel cards

### DIFF
--- a/client/src/Admin/pages/Home/HomePanel.tsx
+++ b/client/src/Admin/pages/Home/HomePanel.tsx
@@ -5,6 +5,8 @@ export interface HomePanelCard {
   content: React.ReactNode
   actionLabel?: string
   onAction?: () => void
+  done?: boolean
+  onToggleDone?: (checked: boolean) => void
 }
 
 interface Props {
@@ -25,9 +27,18 @@ export default function HomePanel({ title, cards, className = '' }: Props) {
           {cards.map((c) => (
             <li
               key={c.key}
-              className="bg-white rounded shadow p-3 flex justify-between items-center"
+              className={`bg-white rounded shadow p-3 flex justify-between items-center ${c.done ? 'bg-green-100' : ''}`}
             >
-              <div>{c.content}</div>
+              <div className="flex items-center gap-2">
+                {c.onToggleDone && (
+                  <input
+                    type="checkbox"
+                    checked={!!c.done}
+                    onChange={(e) => c.onToggleDone!(e.target.checked)}
+                  />
+                )}
+                <div>{c.content}</div>
+              </div>
               {c.onAction && (
                 <button
                   className="text-blue-500 text-sm"

--- a/client/src/Admin/pages/Home/index.tsx
+++ b/client/src/Admin/pages/Home/index.tsx
@@ -7,6 +7,7 @@ import HomePanel, { HomePanelCard } from './HomePanel'
 export default function Home() {
   const [items, setItems] = useState<Appointment[]>([])
   const [upcoming, setUpcoming] = useState<(Appointment & { daysLeft: number })[]>([])
+  const [doneUpcoming, setDoneUpcoming] = useState<number[]>([])
   const [editParams, setEditParams] = useState<{
     clientId?: number
     templateId?: number | null
@@ -68,20 +69,35 @@ export default function Home() {
     onAction: () => handleEdit(a),
   }))
 
-  const upcomingCards: HomePanelCard[] = upcoming.map((a) => {
-    const nextAppt = { ...a, date: a.reocuringDate }
-    return {
-      key: a.id!,
-      content: (
-        <div>
-          <div className="font-medium">{a.client?.name}</div>
-          <div className="text-sm text-gray-600">In {a.daysLeft} days</div>
-        </div>
-      ),
-      actionLabel: 'View',
-      onAction: () => handleEdit(nextAppt),
-    }
-  })
+  const upcomingCards: HomePanelCard[] = upcoming
+    .slice()
+    .sort((a1, a2) => {
+      const d1 = doneUpcoming.includes(a1.id!)
+      const d2 = doneUpcoming.includes(a2.id!)
+      if (d1 === d2) return 0
+      return d1 ? 1 : -1
+    })
+    .map((a) => {
+      const nextAppt = { ...a, date: a.reocuringDate }
+      const done = doneUpcoming.includes(a.id!)
+      return {
+        key: a.id!,
+        content: (
+          <div>
+            <div className="font-medium">{a.client?.name}</div>
+            <div className="text-sm text-gray-600">In {a.daysLeft} days</div>
+          </div>
+        ),
+        actionLabel: 'View',
+        onAction: () => handleEdit(nextAppt),
+        done,
+        onToggleDone: (checked: boolean) => {
+          setDoneUpcoming((prev) =>
+            checked ? [...prev, a.id!] : prev.filter((id) => id !== a.id!)
+          )
+        },
+      }
+    })
 
   return (
     <div className="p-4 space-y-4">


### PR DESCRIPTION
## Summary
- enable 'done' checkbox feature on recurring cards
- keep done cards green and sorted to the bottom

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6889926c5c3c832db20340400b7a55c5