### PR TITLE
Fix invoice send modal

### DIFF
--- a/client/src/Admin/pages/Financing/components/CreateInvoiceModal.tsx
+++ b/client/src/Admin/pages/Financing/components/CreateInvoiceModal.tsx
@@ -26,6 +26,7 @@ export default function CreateInvoiceModal({ appointment, onClose }: Props) {
   const [taxEnabled, setTaxEnabled] = useState(false)
   const [taxPercent, setTaxPercent] = useState('')
   const [comment, setComment] = useState('')
+  const [paid, setPaid] = useState(true)
 
   useEffect(() => {
     const cp = (appointment as any).carpetPrice
@@ -71,6 +72,7 @@ export default function CreateInvoiceModal({ appointment, onClose }: Props) {
       discount: discount ? parseFloat(discount) : undefined,
       taxPercent: taxEnabled ? parseFloat(taxPercent) || 0 : undefined,
       comment: comment || undefined,
+      paid,
     }
     const newWindow = window.open('', '_blank')
     const res = await fetch(`${API_BASE_URL}/invoices`, {
@@ -107,11 +109,10 @@ export default function CreateInvoiceModal({ appointment, onClose }: Props) {
       taxPercent: taxEnabled ? parseFloat(taxPercent) || 0 : undefined,
       comment: comment || undefined,
     }
-    const newWindow = window.open('', '_blank')
     const res = await fetch(`${API_BASE_URL}/invoices`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', 'ngrok-skip-browser-warning': '1' },
-      body: JSON.stringify(payload),
+      body: JSON.stringify({ ...payload, paid }),
     })
     if (res.ok) {
       const data = await res.json()
@@ -123,15 +124,8 @@ export default function CreateInvoiceModal({ appointment, onClose }: Props) {
           body: JSON.stringify({ email }),
         })
       }
-      const url = `${API_BASE_URL}/invoices/${data.id}/pdf`
-      if (newWindow) {
-        newWindow.location.href = url
-      } else {
-        window.location.href = url
-      }
       onClose()
     } else {
-      if (newWindow) newWindow.close()
       await alert('Failed to create invoice')
     }
   }
@@ -208,6 +202,12 @@ export default function CreateInvoiceModal({ appointment, onClose }: Props) {
           {taxEnabled && (
             <input type="number" className="w-full border p-2 rounded mt-1" value={taxPercent} onChange={(e) => setTaxPercent(e.target.value)} placeholder="Percent" />
           )}
+        </div>
+        <div>
+          <label className="flex items-center gap-2 text-sm">
+            <input type="checkbox" checked={!paid} onChange={(e) => setPaid(!e.target.checked)} />
+            Not Paid
+          </label>
         </div>
         <div className="font-medium">Total: ${total.toFixed(2)}</div>
         <div className="flex justify-end gap-2 pt-2">

--- a/server/prisma/migrations/20250730235109_invoice_paid/migration.sql
+++ b/server/prisma/migrations/20250730235109_invoice_paid/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Invoice" ADD COLUMN     "paid" BOOLEAN NOT NULL DEFAULT true;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -171,6 +171,7 @@ model Invoice {
   discount    Float?
   taxPercent  Float?
   comment     String?
+  paid        Boolean  @default(true)
   total       Float
   createdAt   DateTime @default(now())
 }


### PR DESCRIPTION
## Summary
- add paid flag and checkbox to invoice modal
- embed company logo on invoice PDF
- add NOT PAID watermark when applicable
- include new Prisma migration and schema updates
- stop opening a new window when sending invoices

## Testing
- `npx tsc -p server/tsconfig.json` *(fails: needs tsc package)*

------
https://chatgpt.com/codex/tasks/task_e_688aae1e8a7c832d8776b33b12d89686