### PR TITLE
Show admin in appointment and warn on send errors

### DIFF
--- a/client/src/Admin/pages/Calendar/components/DayTimeline.tsx
+++ b/client/src/Admin/pages/Calendar/components/DayTimeline.tsx
@@ -373,6 +373,11 @@ function Day({ appointments, nowOffset, scrollRef, animating, onUpdate, onCreate
             </div>
             <div className="text-sm">Address: {selected.address}</div>
             <div className="text-sm">Type: {selected.type}</div>
+            {selected.admin && (
+              <div className="text-sm">
+                Admin: {selected.admin.name ?? selected.admin.email}
+              </div>
+            )}
             <div className="text-sm">Date &amp; Time: {selected.date.slice(0, 10)} {selected.time}</div>
             {selected.employees && selected.employees.length > 0 && (
               <div className="text-sm">

--- a/client/src/Admin/pages/Calendar/types.ts
+++ b/client/src/Admin/pages/Calendar/types.ts
@@ -32,6 +32,7 @@ export interface Appointment {
   noTeam?: boolean
   carpetRooms?: number
   carpetPrice?: number
+  adminId?: number
   reoccurring?: boolean
   reocuringDate?: string
   recurringDone?: boolean
@@ -48,5 +49,6 @@ export interface Appointment {
     | 'DELETED'
   client?: import('../Clients/components/types').Client
   employees?: import('../Employees/components/types').Employee[]
+  admin?: { id: number; name: string | null; email: string }
   createdAt?: string
 }

--- a/client/src/Admin/pages/Financing/components/CreateInvoiceModal.tsx
+++ b/client/src/Admin/pages/Financing/components/CreateInvoiceModal.tsx
@@ -118,12 +118,17 @@ export default function CreateInvoiceModal({ appointment, onClose }: Props) {
     })
     if (res.ok) {
       const data = await res.json()
-      await fetch(`${API_BASE_URL}/invoices/${data.id}/send`, {
+      const sendRes = await fetch(`${API_BASE_URL}/invoices/${data.id}/send`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'ngrok-skip-browser-warning': '1' },
         body: JSON.stringify({ email }),
       })
-      onClose()
+      if (sendRes.ok) {
+        onClose()
+      } else {
+        const text = await sendRes.text()
+        await alert(text || 'Failed to send invoice')
+      }
     } else {
       await alert('Failed to create invoice')
     }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -708,7 +708,7 @@ app.get('/appointments', async (req: Request, res: Response) => {
         status: { notIn: ['DELETED', 'RESCHEDULE_OLD'] },
       },
       orderBy: { time: 'asc' },
-      include: { client: true, employees: true },
+      include: { client: true, employees: true, admin: true },
     })
     res.json(appts)
   } catch (e) {
@@ -722,7 +722,7 @@ app.get('/appointments/lineage/:lineage', async (req: Request, res: Response) =>
     const appts = await prisma.appointment.findMany({
       where: { lineage },
       orderBy: { date: 'asc' },
-      include: { client: true, employees: true },
+      include: { client: true, employees: true, admin: true },
     })
     res.json(appts)
   } catch {
@@ -738,7 +738,7 @@ app.get('/appointments/no-team', async (_req: Request, res: Response) => {
         status: { notIn: ['DELETED', 'RESCHEDULE_OLD', 'CANCEL'] },
       },
       orderBy: [{ date: 'asc' }, { time: 'asc' }],
-      include: { client: true, employees: true },
+      include: { client: true, employees: true, admin: true },
     })
     res.json(appts)
   } catch (err) {
@@ -760,7 +760,7 @@ app.get('/appointments/upcoming-recurring', async (_req: Request, res: Response)
         status: { notIn: ['DELETED', 'CANCEL'] },
       },
       orderBy: { reocuringDate: 'asc' },
-      include: { client: true, employees: true },
+      include: { client: true, employees: true, admin: true },
     })
     const results = appts.map((a: any) => ({
       ...a,
@@ -781,7 +781,7 @@ app.put('/appointments/:id/recurring-done', async (req: Request, res: Response) 
     const appt = await prisma.appointment.update({
       where: { id },
       data: { recurringDone: done },
-      include: { client: true, employees: true },
+      include: { client: true, employees: true, admin: true },
     })
     res.json(appt)
   } catch (err) {
@@ -897,6 +897,7 @@ app.post('/appointments/recurring', async (req: Request, res: Response) => {
           },
         }),
       },
+      include: { client: true, employees: true, admin: true },
     })
     if (!noTeam && employeeIds.length) {
       await syncPayrollItems(appt.id, employeeIds)
@@ -1007,6 +1008,7 @@ app.post('/appointments', async (req: Request, res: Response) => {
           },
         }),
       },
+      include: { client: true, employees: true, admin: true },
     })
 
     if (!noTeam && employeeIds.length) {
@@ -1118,7 +1120,7 @@ app.put('/appointments/:id', async (req: Request, res: Response) => {
       data.observation = null
     }
     const future = req.query.future === 'true'
-    const current = await prisma.appointment.findUnique({ where: { id }, include: { employees: true, client: true } })
+    const current = await prisma.appointment.findUnique({ where: { id }, include: { employees: true, client: true, admin: true } })
     if (!current) return res.status(404).json({ error: 'Not found' })
 
     const convertToRecurring =
@@ -1138,7 +1140,7 @@ app.put('/appointments/:id', async (req: Request, res: Response) => {
       const updated = await prisma.appointment.update({
         where: { id: current.id },
         data: { ...data, lineage, reoccurring: true, reocuringDate: nextDate },
-        include: { employees: true, client: true },
+        include: { employees: true, client: true, admin: true },
       })
       return res.json(updated)
     }
@@ -1177,7 +1179,7 @@ app.put('/appointments/:id', async (req: Request, res: Response) => {
 
       const appts = await prisma.appointment.findMany({
         where: { lineage: current.lineage, date: { gte: current.date } },
-        include: { client: true, employees: true },
+        include: { client: true, employees: true, admin: true },
         orderBy: { date: 'asc' },
       })
       res.json(appts)
@@ -1185,7 +1187,7 @@ app.put('/appointments/:id', async (req: Request, res: Response) => {
       const appt = await prisma.appointment.update({
         where: { id },
         data,
-        include: { client: true, employees: true },
+        include: { client: true, employees: true, admin: true },
       })
       if (employeeIds && !noTeam) {
         await syncPayrollItems(appt.id, employeeIds)
@@ -1205,7 +1207,7 @@ app.post('/appointments/:id/send-info', async (req: Request, res: Response) => {
     const note = String((req.body as any).note || '')
     const appt = await prisma.appointment.findUnique({
       where: { id },
-      include: { client: true, employees: true },
+      include: { client: true, employees: true, admin: true },
     })
     if (!appt) return res.status(404).json({ error: 'Not found' })
 
@@ -1240,7 +1242,7 @@ app.post('/appointments/:id/send-info', async (req: Request, res: Response) => {
     const updated = await prisma.appointment.update({
       where: { id },
       data: { infoSent: true },
-      include: { client: true, employees: true },
+      include: { client: true, employees: true, admin: true },
     })
 
     res.json(updated)


### PR DESCRIPTION
## Summary
- include admin details when returning appointments from the server
- display the appointment admin in the calendar modal
- surface errors when sending invoices via email

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` in `server`

------
https://chatgpt.com/codex/tasks/task_e_688ac0dad11c832d9db346e87ce06782