### PR TITLE
Add invoice jump and payroll credit handling

### DIFF
--- a/client/src/Admin/AdminDashboard.tsx
+++ b/client/src/Admin/AdminDashboard.tsx
@@ -11,8 +11,10 @@ interface Props {
 
 export default function AdminDashboard({ onLogout }: Props) {
   const navigate = useNavigate()
+  const isSafe = localStorage.getItem('safe') === 'true'
   const signOut = () => {
     localStorage.removeItem('role')
+    localStorage.removeItem('safe')
     onLogout()
     navigate('/')
   }
@@ -26,7 +28,13 @@ export default function AdminDashboard({ onLogout }: Props) {
           <li><Link className="px-2 py-1" to="/dashboard/clients">Clients</Link></li>
           <li><Link className="px-2 py-1" to="/dashboard/employees">Employees</Link></li>
           <li><Link className="px-2 py-1" to="/dashboard/financing">Financing</Link></li>
-          <li><button className="px-2 py-1" onClick={signOut}>Sign Out</button></li>
+          {!isSafe && (
+            <li>
+              <button className="px-2 py-1" onClick={signOut}>
+                Sign Out
+              </button>
+            </li>
+          )}
         </ul>
       </nav>
       <main className="flex-1 pb-16 md:pb-0">

--- a/client/src/Admin/pages/Calendar/components/DayTimeline.tsx
+++ b/client/src/Admin/pages/Calendar/components/DayTimeline.tsx
@@ -6,6 +6,7 @@ import {
   type Ref,
 } from 'react'
 import { createPortal } from 'react-dom'
+import { useNavigate } from 'react-router-dom'
 import type { Appointment } from '../types'
 import { API_BASE_URL } from '../../../../api'
 import { useModal } from '../../../../ModalProvider'
@@ -52,6 +53,7 @@ interface DayProps {
 
 function Day({ appointments, nowOffset, scrollRef, animating, onUpdate, onCreate, onEdit }: DayProps) {
   const { alert, confirm } = useModal()
+  const navigate = useNavigate()
   const [selected, setSelected] = useState<Appointment | null>(null)
   const [overlayTop, setOverlayTop] = useState(0)
   const [overlayHeight, setOverlayHeight] = useState(0)
@@ -573,6 +575,17 @@ function Day({ appointments, nowOffset, scrollRef, animating, onUpdate, onCreate
                   Send Info
                 </button>
               )}
+              <button
+                className="px-4 py-1 bg-green-600 text-white rounded"
+                onClick={() => {
+                  if (!selected) return
+                  navigate(
+                    `/dashboard/financing/invoice?date=${selected.date.slice(0, 10)}&appt=${selected.id}`,
+                  )
+                }}
+              >
+                Invoice
+              </button>
               <button
                 className="px-4 py-1 bg-green-500 text-white rounded disabled:opacity-50"
                 disabled={paid && (!paymentMethod || (paymentMethod === 'OTHER' && !otherPayment))}

--- a/client/src/Admin/pages/Calendar/components/MonthSelector.tsx
+++ b/client/src/Admin/pages/Calendar/components/MonthSelector.tsx
@@ -6,6 +6,7 @@ interface Props {
   show: boolean
   setShow: (v: boolean) => void
   monthInfo: { startDay: number; endDay: number; daysInMonth: number } | null
+  counts: Record<string, number>
 }
 
 function getPaddedMonthDays(date: Date) {
@@ -28,9 +29,10 @@ type MonthGridProps = {
   selected: Date
   setSelected: (d: Date) => void
   setShow: (v: boolean) => void
+  counts: Record<string, number>
 }
 
-function MonthGrid({ days, selected, setSelected, setShow }: MonthGridProps) {
+function MonthGrid({ days, selected, setSelected, setShow, counts }: MonthGridProps) {
   return (
     <div className="grid grid-cols-7 text-center flex-shrink-0 w-1/3">
       {days.map((day, idx) =>
@@ -41,13 +43,18 @@ function MonthGrid({ days, selected, setSelected, setShow }: MonthGridProps) {
               setSelected(day)
               setShow(false)
             }}
-            className={`p-1 ${
+            className={`p-1 flex flex-col items-center ${
               day.toDateString() === selected.toDateString()
                 ? 'bg-blue-500 text-white'
                 : 'hover:bg-gray-200'
             }`}
           >
             {day.getDate()}
+            {counts[day.toISOString().slice(0, 10)] ? (
+              <span className="mt-1 inline-flex items-center justify-center w-4 h-4 text-[10px] bg-blue-600 text-white rounded-full">
+                {counts[day.toISOString().slice(0, 10)]}
+              </span>
+            ) : null}
           </button>
         ) : (
           <div key={idx} className="p-1" />
@@ -63,6 +70,7 @@ export default function MonthSelector({
   show,
   setShow,
   monthInfo,
+  counts,
 }: Props) {
   const containerRef = useRef<HTMLDivElement>(null)
   const touchStartX = useRef<number | null>(null)
@@ -250,18 +258,21 @@ export default function MonthSelector({
               selected={selected}
               setSelected={setSelected}
               setShow={setShow}
+              counts={counts}
             />
             <MonthGrid
               days={paddedCurrent}
               selected={selected}
               setSelected={setSelected}
               setShow={setShow}
+              counts={counts}
             />
             <MonthGrid
               days={nextDays}
               selected={selected}
               setSelected={setSelected}
               setShow={setShow}
+              counts={counts}
             />
           </div>
         </div>

--- a/client/src/Admin/pages/Calendar/index.tsx
+++ b/client/src/Admin/pages/Calendar/index.tsx
@@ -46,6 +46,7 @@ export default function Calendar() {
   const [showMonth, setShowMonth] = useState(false)
   const [nowOffset, setNowOffset] = useState<number | null>(null)
   const [monthInfo, setMonthInfo] = useState<{ startDay: number; endDay: number; daysInMonth: number } | null>(null)
+  const [monthCounts, setMonthCounts] = useState<Record<string, number>>({})
   const [appointments, setAppointments] = useState<{
     prev: Appointment[]
     current: Appointment[]
@@ -168,6 +169,9 @@ export default function Calendar() {
     fetchJson(`${API_BASE_URL}/month-info?year=${year}&month=${month}`)
       .then((data) => setMonthInfo(data))
       .catch(() => setMonthInfo(null))
+    fetchJson(`${API_BASE_URL}/appointments/month-counts?year=${year}&month=${month}`)
+      .then((data) => setMonthCounts(data as Record<string, number>))
+      .catch(() => setMonthCounts({}))
   }, [selected.getFullYear(), selected.getMonth()])
 
   useEffect(() => {
@@ -224,6 +228,7 @@ export default function Calendar() {
           show={showMonth}
           setShow={setShowMonth}
           monthInfo={monthInfo}
+          counts={monthCounts}
         />
         <WeekSelector
           days={days}

--- a/client/src/Admin/pages/Financing/Invoice.tsx
+++ b/client/src/Admin/pages/Financing/Invoice.tsx
@@ -1,19 +1,33 @@
 import { useEffect, useState } from 'react'
-import { Link } from 'react-router-dom'
+import { Link, useLocation } from 'react-router-dom'
 import { API_BASE_URL, fetchJson } from '../../../api'
 import type { Appointment } from '../Calendar/types'
 import CreateInvoiceModal from './components/CreateInvoiceModal'
 
 export default function Invoice() {
-  const [date, setDate] = useState(() => new Date().toISOString().slice(0, 10))
+  const location = useLocation()
+  const params = new URLSearchParams(location.search)
+  const [date, setDate] = useState(() =>
+    params.get('date') || new Date().toISOString().slice(0, 10),
+  )
   const [appointments, setAppointments] = useState<Appointment[]>([])
   const [selected, setSelected] = useState<Appointment | null>(null)
+  const initialAppt = params.get('appt')
 
   useEffect(() => {
     fetchJson(`${API_BASE_URL}/appointments?date=${date}`)
       .then((d) => setAppointments(d))
       .catch(() => setAppointments([]))
   }, [date])
+
+  useEffect(() => {
+    if (initialAppt && appointments.length) {
+      const match = appointments.find((a) => String(a.id) === initialAppt)
+      if (match) {
+        setSelected(match)
+      }
+    }
+  }, [initialAppt, appointments])
 
   return (
     <div className="p-4 pb-16">

--- a/client/src/Landing/components/Login.tsx
+++ b/client/src/Landing/components/Login.tsx
@@ -31,6 +31,9 @@ export default function Login({ onLogin }: LoginProps) {
       if (data.role) {
         onLogin(data.role as Role)
         localStorage.setItem('role', data.role)
+        if (data.user && typeof data.user.safe !== 'undefined') {
+          localStorage.setItem('safe', data.user.safe ? 'true' : 'false')
+        }
       }
 
       searchParams.delete('code')
@@ -61,6 +64,9 @@ export default function Login({ onLogin }: LoginProps) {
       if (data.role) {
         onLogin(data.role as Role)
         localStorage.setItem('role', data.role)
+        if (data.user && typeof data.user.safe !== 'undefined') {
+          localStorage.setItem('safe', data.user.safe ? 'true' : 'false')
+        }
       }
     },
     onError: () => {

--- a/client/src/User/UserDashboard.tsx
+++ b/client/src/User/UserDashboard.tsx
@@ -6,8 +6,10 @@ interface Props {
 
 export default function UserDashboard({ onLogout }: Props) {
   const navigate = useNavigate()
+  const isSafe = localStorage.getItem('safe') === 'true'
   const signOut = () => {
     localStorage.removeItem('role')
+    localStorage.removeItem('safe')
     onLogout()
     navigate('/')
   }
@@ -16,7 +18,11 @@ export default function UserDashboard({ onLogout }: Props) {
     <div className="p-4">
       <div className="flex justify-between items-center mb-4">
         <h2 className="text-xl font-semibold">User Dashboard</h2>
-        <button className="px-2 py-1" onClick={signOut}>Sign Out</button>
+        {!isSafe && (
+          <button className="px-2 py-1" onClick={signOut}>
+            Sign Out
+          </button>
+        )}
       </div>
       <p>Welcome, user!</p>
     </div>

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -13,6 +13,7 @@ model User {
   email String @unique
   name  String?
   role  Role   @default(EMPLOYEE)
+  safe  Boolean @default(false)
 
   appointments Appointment[] @relation("AdminAppointments")
 }


### PR DESCRIPTION
## Summary
- support user safe flag
- link appointments to invoice creation
- show appointment counts in month view
- keep negative payroll balance as credit
- provide API for monthly appointment counts

## Testing
- `npm run build` *(fails: vite not found)*
- `npm run build` in server *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_688ac5465734832da78f851a06f03edb