### PR TITLE
Add manual payroll item persistence

### DIFF
--- a/server/prisma/migrations/20250731023000_manual_payroll_item/migration.sql
+++ b/server/prisma/migrations/20250731023000_manual_payroll_item/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE "ManualPayrollItem" (
+    "id" SERIAL NOT NULL,
+    "employeeId" INTEGER NOT NULL,
+    "name" TEXT NOT NULL,
+    "amount" DOUBLE PRECISION NOT NULL,
+    "paid" BOOLEAN NOT NULL DEFAULT false,
+    "paymentId" INTEGER,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "ManualPayrollItem_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "ManualPayrollItem" ADD CONSTRAINT "ManualPayrollItem_employeeId_fkey" FOREIGN KEY ("employeeId") REFERENCES "Employee"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ManualPayrollItem" ADD CONSTRAINT "ManualPayrollItem_paymentId_fkey" FOREIGN KEY ("paymentId") REFERENCES "EmployeePayment"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -42,6 +42,7 @@ model Employee {
 
   payrollItems PayrollItem[]       @relation("EmployeePayrollItems")
   payments     EmployeePayment[]   @relation("EmployeePayments")
+  manualItems  ManualPayrollItem[]
 
   templateLinks EmployeeTemplateEmployee[] @relation("EmployeeOnTemplate")
 }
@@ -198,4 +199,18 @@ model EmployeePayment {
 
   employee   Employee   @relation("EmployeePayments", fields: [employeeId], references: [id])
   items      PayrollItem[]
+  manualItems ManualPayrollItem[]
+}
+
+model ManualPayrollItem {
+  id         Int       @id @default(autoincrement())
+  employeeId Int
+  name       String
+  amount     Float
+  paid       Boolean   @default(false)
+  paymentId  Int?
+  createdAt  DateTime  @default(now())
+
+  employee  Employee        @relation(fields: [employeeId], references: [id])
+  payment   EmployeePayment? @relation(fields: [paymentId], references: [id])
 }


### PR DESCRIPTION
## Summary
- support manual payroll entries in the database
- expose `/payroll/manual` endpoint
- include manual items when calculating payroll dues and payments
- show client UI for saving manual items via the new endpoint
- database migration for manual payroll items

## Testing
- `npm run lint` *(fails: 105 errors)*
- `npm run build` in `server`


------
https://chatgpt.com/codex/tasks/task_e_688ad396f16c832d8e0585900fd99a59