### PR TITLE
Allow 11-digit phone numbers

### DIFF
--- a/client/src/Admin/pages/Clients/components/ClientForm.tsx
+++ b/client/src/Admin/pages/Clients/components/ClientForm.tsx
@@ -41,7 +41,7 @@ export default function ClientForm() {
 
   const handleNumberChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target
-    const digits = value.replace(/\D/g, '').slice(0, 10)
+    const digits = value.replace(/\D/g, '').slice(0, 11)
     const updated = { ...data, [name]: digits }
     persist(updated)
     setData(updated)
@@ -57,7 +57,7 @@ export default function ClientForm() {
     e.preventDefault()
     const payload = {
       name: data.name,
-      number: data.number,
+      number: data.number.length === 10 ? '1' + data.number : data.number,
       notes: data.notes,
       disabled: data.disabled ?? false,
     }
@@ -92,7 +92,7 @@ export default function ClientForm() {
       </div>
       <div>
         <label htmlFor="client-number" className="block text-sm">
-          Number <span className="text-red-500">*</span>
+          Phone number <span className="text-red-500">*</span>
         </label>
         <input
           id="client-number"
@@ -100,7 +100,7 @@ export default function ClientForm() {
           value={data.number}
           onChange={handleNumberChange}
           type="tel"
-          pattern="\d{10}"
+          pattern="\d{10,11}"
           required
           className="w-full border p-2 rounded"
         />

--- a/client/src/Admin/pages/Employees/components/EmployeeForm.tsx
+++ b/client/src/Admin/pages/Employees/components/EmployeeForm.tsx
@@ -53,7 +53,7 @@ export default function EmployeeForm() {
 
   const handleNumberChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target
-    const digits = value.replace(/\D/g, '').slice(0, 10)
+    const digits = value.replace(/\D/g, '').slice(0, 11)
     const updated = { ...data, [name]: digits }
     persist(updated)
     setData(updated)
@@ -63,7 +63,7 @@ export default function EmployeeForm() {
     e.preventDefault()
     const payload = {
       name: data.name,
-      number: data.number,
+      number: data.number.length === 10 ? '1' + data.number : data.number,
       notes: data.notes,
       experienced: data.experienced,
       disabled: data.disabled ?? false,
@@ -99,7 +99,7 @@ export default function EmployeeForm() {
       </div>
       <div>
         <label htmlFor="employee-number" className="block text-sm">
-          Number <span className="text-red-500">*</span>
+          Phone number <span className="text-red-500">*</span>
         </label>
         <input
           id="employee-number"
@@ -107,7 +107,7 @@ export default function EmployeeForm() {
           value={data.number}
           onChange={handleNumberChange}
           type="tel"
-          pattern="\d{10}"
+          pattern="\d{10,11}"
           required
           className="w-full border p-2 rounded"
         />


### PR DESCRIPTION
## Summary
- accept phone numbers up to 11 digits
- store 10‑digit numbers with leading `1`
- send SMS with `+1` format
- update employee and client forms to validate up to 11 digits and display `Phone number` label

## Testing
- `npm --prefix server run build`
- `npm --prefix client run build`


------
https://chatgpt.com/codex/tasks/task_e_688b0fbe7704832d9c7beafa9bf9fcdf