### PR TITLE
Show counts in mobile month view

### DIFF
--- a/client/src/Admin/pages/Calendar/components/MonthSelector.tsx
+++ b/client/src/Admin/pages/Calendar/components/MonthSelector.tsx
@@ -43,7 +43,7 @@ function MonthGrid({ days, selected, setSelected, setShow, counts }: MonthGridPr
               setSelected(day)
               setShow(false)
             }}
-            className={`p-1 flex flex-col items-center ${
+            className={`relative p-1 flex flex-col items-center ${
               day.toDateString() === selected.toDateString()
                 ? 'bg-blue-500 text-white'
                 : 'hover:bg-gray-200'
@@ -51,7 +51,7 @@ function MonthGrid({ days, selected, setSelected, setShow, counts }: MonthGridPr
           >
             {day.getDate()}
             {counts[day.toISOString().slice(0, 10)] ? (
-              <span className="mt-1 inline-flex items-center justify-center w-4 h-4 text-[10px] bg-blue-600 text-white rounded-full">
+              <span className="absolute bottom-1 right-1 inline-flex items-center justify-center w-4 h-4 text-[10px] bg-blue-600 text-white rounded-full">
                 {counts[day.toISOString().slice(0, 10)]}
               </span>
             ) : null}

--- a/client/src/Admin/pages/Calendar/components/WeekSelector.tsx
+++ b/client/src/Admin/pages/Calendar/components/WeekSelector.tsx
@@ -7,9 +7,10 @@ interface Props {
   showMonth: boolean
   prevWeek: () => void
   nextWeek: () => void
+  counts: Record<string, number>
 }
 
-export default function WeekSelector({ days, selected, setSelected, showMonth, prevWeek, nextWeek }: Props) {
+export default function WeekSelector({ days, selected, setSelected, showMonth, prevWeek, nextWeek, counts }: Props) {
   const weekTouchStart = useRef<number | null>(null)
 
   return (
@@ -30,6 +31,7 @@ export default function WeekSelector({ days, selected, setSelected, showMonth, p
     >
       {days.map((day) => {
         const isSelected = day.toDateString() === selected.toDateString()
+        const count = counts[day.toISOString().slice(0, 10)]
         return (
           <button
             key={day.toDateString()}
@@ -39,7 +41,14 @@ export default function WeekSelector({ days, selected, setSelected, showMonth, p
             <div className="text-xs">
               {day.toLocaleDateString('default', { weekday: 'short' })}
             </div>
-            <div className="text-sm font-medium">{day.getDate()}</div>
+            <div className="text-sm font-medium flex flex-col items-center">
+              {day.getDate()}
+              {count ? (
+                <span className="mt-1 inline-flex items-center justify-center w-4 h-4 text-[10px] bg-blue-600 text-white rounded-full">
+                  {count}
+                </span>
+              ) : null}
+            </div>
           </button>
         )
       })}

--- a/client/src/Admin/pages/Calendar/index.tsx
+++ b/client/src/Admin/pages/Calendar/index.tsx
@@ -237,6 +237,7 @@ export default function Calendar() {
           showMonth={showMonth}
           prevWeek={prevWeek}
           nextWeek={nextWeek}
+          counts={monthCounts}
         />
       </div>
         <DayTimeline


### PR DESCRIPTION
## Summary
- overlay appointment count circles in `MonthSelector`

## Testing
- `npm --prefix client run lint` *(fails: existing lint errors)*
- `npx tsc -p client` *(fails to compile TypeScript)*

------
https://chatgpt.com/codex/tasks/task_e_688b0ce18adc832db11611e8801e51b9