### PR TITLE
Add delete option for client and employee pages

### DIFF
--- a/client/src/Admin/pages/Clients/components/ClientForm.tsx
+++ b/client/src/Admin/pages/Clients/components/ClientForm.tsx
@@ -6,7 +6,7 @@ import { Client } from './types'
 import { API_BASE_URL, fetchJson } from '../../../../api'
 
 export default function ClientForm() {
-  const { alert } = useModal()
+  const { alert, confirm } = useModal()
   const { id } = useParams()
   const navigate = useNavigate()
   const isNew = id === undefined
@@ -75,6 +75,23 @@ export default function ClientForm() {
     navigate('..')
   }
 
+  const handleDelete = async () => {
+    if (!id) return
+    const ok = await confirm('Delete this client?')
+    if (!ok) return
+    const res = await fetch(`${API_BASE_URL}/clients/${id}`, {
+      method: 'DELETE',
+      headers: { 'ngrok-skip-browser-warning': '1' },
+    })
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}))
+      await alert(err.error || 'Failed to delete')
+      return
+    }
+    clearFormPersistence(storageKey)
+    navigate('..')
+  }
+
   return (
     <form onSubmit={handleSubmit} className="p-4 space-y-3">
       <div>
@@ -125,9 +142,20 @@ export default function ClientForm() {
         />
         <label htmlFor="disabled" className="text-sm">Disable</label>
       </div>
-      <button className="bg-blue-500 text-white px-4 py-2 rounded" type="submit">
-        Save
-      </button>
+      <div className="flex gap-2">
+        <button className="bg-blue-500 text-white px-4 py-2 rounded" type="submit">
+          Save
+        </button>
+        {!isNew && (
+          <button
+            type="button"
+            onClick={handleDelete}
+            className="bg-red-500 text-white px-4 py-2 rounded"
+          >
+            Delete
+          </button>
+        )}
+      </div>
     </form>
   )
 }

--- a/client/src/Admin/pages/Employees/components/EmployeeForm.tsx
+++ b/client/src/Admin/pages/Employees/components/EmployeeForm.tsx
@@ -6,7 +6,7 @@ import { API_BASE_URL, fetchJson } from '../../../../api'
 import useFormPersistence, { clearFormPersistence, loadFormPersistence } from '../../../../useFormPersistence'
 
 export default function EmployeeForm() {
-  const { alert } = useModal()
+  const { alert, confirm } = useModal()
   const { id } = useParams()
   const navigate = useNavigate()
   const isNew = id === undefined
@@ -76,6 +76,23 @@ export default function EmployeeForm() {
     if (!res.ok) {
       const err = await res.json().catch(() => ({}))
       await alert(err.error || 'Failed to save')
+      return
+    }
+    clearFormPersistence(storageKey)
+    navigate('..')
+  }
+
+  const handleDelete = async () => {
+    if (!id) return
+    const ok = await confirm('Delete this employee?')
+    if (!ok) return
+    const res = await fetch(`${API_BASE_URL}/employees/${id}`, {
+      method: 'DELETE',
+      headers: { 'ngrok-skip-browser-warning': '1' },
+    })
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}))
+      await alert(err.error || 'Failed to delete')
       return
     }
     clearFormPersistence(storageKey)
@@ -156,6 +173,15 @@ export default function EmployeeForm() {
         >
           Cancel
         </button>
+        {!isNew && (
+          <button
+            type="button"
+            onClick={handleDelete}
+            className="bg-red-500 text-white px-4 py-2 rounded"
+          >
+            Delete
+          </button>
+        )}
       </div>
     </form>
   )

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -452,6 +452,16 @@ app.put('/clients/:id', async (req: Request, res: Response) => {
   }
 })
 
+app.delete('/clients/:id', async (req: Request, res: Response) => {
+  const id = parseInt(req.params.id, 10)
+  try {
+    await prisma.client.delete({ where: { id } })
+    res.json({ ok: true })
+  } catch (e) {
+    res.status(500).json({ error: 'Failed to delete client' })
+  }
+})
+
 app.get('/employees', async (req: Request, res: Response) => {
   const searchTerm = String(req.query.search || '').trim()
   const skip = parseInt(String(req.query.skip || '0'), 10)
@@ -546,6 +556,16 @@ app.put('/employees/:id', async (req: Request, res: Response) => {
     res.json(employee)
   } catch (e) {
     res.status(500).json({ error: 'Failed to update employee' })
+  }
+})
+
+app.delete('/employees/:id', async (req: Request, res: Response) => {
+  const id = parseInt(req.params.id, 10)
+  try {
+    await prisma.employee.delete({ where: { id } })
+    res.json({ ok: true })
+  } catch (e) {
+    res.status(500).json({ error: 'Failed to delete employee' })
   }
 })
 


### PR DESCRIPTION
## Summary
- allow deleting clients and employees via new API endpoints
- add delete button with confirmation modal on client and employee forms

## Testing
- `npm run lint` in `client`
- `npm run build` in `server`


------
https://chatgpt.com/codex/tasks/task_e_688b121a5744832d8bb87035f9856149