### PR TITLE
Fix payroll items on cancelled appointments and allow cascaded deletes

### DIFF
--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -54,7 +54,7 @@ model Appointment {
   adminId        Int
   admin          User            @relation("AdminAppointments", fields: [adminId], references: [id])
   clientId        Int
-  client          Client          @relation(fields: [clientId], references: [id])
+  client          Client          @relation(fields: [clientId], references: [id], onDelete: Cascade)
   type            AppointmentType
   address         String
   cityStateZip    String?
@@ -100,7 +100,7 @@ model AppointmentTemplate {
   carpetRooms      Int?
   carpetPrice      Float?
   clientId          Int
-  client            Client             @relation(fields: [clientId], references: [id])
+  client            Client             @relation(fields: [clientId], references: [id], onDelete: Cascade)
   employeeTemplates EmployeeTemplate[]
   createdAt         DateTime?          @default(now())
   updatedAt         DateTime?          @updatedAt
@@ -126,7 +126,7 @@ model EmployeeTemplateEmployee {
   employeeTemplateId Int
   employeeTemplate   EmployeeTemplate @relation(fields: [employeeTemplateId], references: [id])
 
-  employee           Employee @relation("EmployeeOnTemplate", fields: [employeeId], references: [id])
+  employee           Employee @relation("EmployeeOnTemplate", fields: [employeeId], references: [id], onDelete: Cascade)
 }
 
 enum PaymentMethod {
@@ -185,8 +185,8 @@ model PayrollItem {
   paid          Boolean      @default(false)
   paymentId     Int?
 
-  appointment   Appointment  @relation(fields: [appointmentId], references: [id])
-  employee      Employee     @relation("EmployeePayrollItems", fields: [employeeId], references: [id])
+  appointment   Appointment  @relation(fields: [appointmentId], references: [id], onDelete: Cascade)
+  employee      Employee     @relation("EmployeePayrollItems", fields: [employeeId], references: [id], onDelete: Cascade)
   payment       EmployeePayment? @relation(fields: [paymentId], references: [id])
 }
 
@@ -197,7 +197,7 @@ model EmployeePayment {
   extra      Float      @default(0)
   createdAt  DateTime   @default(now())
 
-  employee   Employee   @relation("EmployeePayments", fields: [employeeId], references: [id])
+  employee   Employee   @relation("EmployeePayments", fields: [employeeId], references: [id], onDelete: Cascade)
   items      PayrollItem[]
   manualItems ManualPayrollItem[]
 }
@@ -211,6 +211,6 @@ model ManualPayrollItem {
   paymentId  Int?
   createdAt  DateTime  @default(now())
 
-  employee  Employee        @relation(fields: [employeeId], references: [id])
+  employee  Employee        @relation(fields: [employeeId], references: [id], onDelete: Cascade)
   payment   EmployeePayment? @relation(fields: [paymentId], references: [id])
 }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -960,7 +960,7 @@ app.post('/appointments/recurring', async (req: Request, res: Response) => {
       },
       include: { client: true, employees: true, admin: true },
     })
-    if (!noTeam && employeeIds.length) {
+    if (!noTeam && employeeIds.length && !['CANCEL', 'DELETED'].includes(status)) {
       await syncPayrollItems(appt.id, employeeIds)
     }
 
@@ -1250,7 +1250,9 @@ app.put('/appointments/:id', async (req: Request, res: Response) => {
         data,
         include: { client: true, employees: true, admin: true },
       })
-      if (employeeIds && !noTeam) {
+      if (appt.status === 'CANCEL' || appt.status === 'DELETED') {
+        await prisma.payrollItem.deleteMany({ where: { appointmentId: appt.id } })
+      } else if (employeeIds && !noTeam) {
         await syncPayrollItems(appt.id, employeeIds)
       }
       res.json(appt)


### PR DESCRIPTION
## Summary
- remove payroll items when appointments are cancelled
- skip payroll sync for cancelled appointments on create
- cascade deletes in Prisma schema so employees and clients can be removed

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688b154a8fec832d928609af1ce6ebe1