### PR TITLE
Update calendar counts dynamically

### DIFF
--- a/client/src/Admin/pages/Calendar/components/CreateAppointmentModal.tsx
+++ b/client/src/Admin/pages/Calendar/components/CreateAppointmentModal.tsx
@@ -7,7 +7,7 @@ import { useModal } from '../../../../ModalProvider'
 
 interface Props {
   onClose: () => void
-  onCreated: () => void
+  onCreated: (appt: import('../types').Appointment) => void
   initialClientId?: number
   initialTemplateId?: number
   newStatus?: import('../types').Appointment['status']
@@ -735,7 +735,8 @@ const preserveTeamRef = useRef(false)
       body: JSON.stringify(payload),
     })
     if (res.ok) {
-      onCreated()
+      const appt = await res.json()
+      onCreated(appt)
       handleCancel()
     } else {
       await alert('Failed to create appointment')

--- a/client/src/Admin/pages/Home/index.tsx
+++ b/client/src/Admin/pages/Home/index.tsx
@@ -130,7 +130,7 @@ export default function Home() {
       {editParams && (
         <CreateAppointmentModal
           onClose={() => setEditParams(null)}
-          onCreated={async () => {
+          onCreated={async (appt) => {
             if (editParams?.fromRecurring && editParams.appointment?.id) {
               try {
                 await fetchJson(


### PR DESCRIPTION
## Summary
- refresh monthly appointment counts when appointments are created or updated
- return the created appointment from the modal so callers know its date
- update Home page and Calendar page to accept the new `onCreated` argument

## Testing
- `npx tsc -p tsconfig.json` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_688b1a827dfc832d9a3e5c5721af5af8