### PR TITLE
Add appointment payroll extras

### DIFF
--- a/client/src/Admin/pages/Calendar/components/DayTimeline.tsx
+++ b/client/src/Admin/pages/Calendar/components/DayTimeline.tsx
@@ -68,6 +68,9 @@ function Day({ appointments, nowOffset, scrollRef, animating, onUpdate, onCreate
   const [showSendInfo, setShowSendInfo] = useState(false)
   const [note, setNote] = useState('')
   const [observation, setObservation] = useState('')
+  const [extraFor, setExtraFor] = useState<number | null>(null)
+  const [extraName, setExtraName] = useState('')
+  const [extraAmount, setExtraAmount] = useState('')
 
   const updateAppointment = async (data: {
     status?: Appointment['status']
@@ -141,6 +144,33 @@ function Day({ appointments, nowOffset, scrollRef, animating, onUpdate, onCreate
     } else {
       await alert('Failed to send info')
     }
+  }
+
+  const openExtra = (empId: number) => {
+    setExtraFor(empId)
+    setExtraName('')
+    setExtraAmount('')
+  }
+
+  const saveExtra = async () => {
+    if (!selected || extraFor == null) return
+    const amt = parseFloat(extraAmount) || 0
+    await fetch(`${API_BASE_URL}/payroll/extra`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'ngrok-skip-browser-warning': '1',
+      },
+      body: JSON.stringify({
+        appointmentId: selected.id,
+        employeeId: extraFor,
+        name: extraName || 'Extra',
+        amount: amt,
+      }),
+    })
+    setExtraFor(null)
+    setExtraName('')
+    setExtraAmount('')
   }
 
   useEffect(() => {
@@ -417,6 +447,12 @@ function Day({ appointments, nowOffset, scrollRef, animating, onUpdate, onCreate
                             </>
                           ) : null}
                         </span>
+                        <button
+                          className="text-blue-500 text-xs ml-2"
+                          onClick={() => openExtra(e.id!)}
+                        >
+                          Add extra
+                        </button>
                       </li>
                     )
                   })}
@@ -722,6 +758,40 @@ function Day({ appointments, nowOffset, scrollRef, animating, onUpdate, onCreate
                       onClick={handleSendInfo}
                     >
                       Send
+                    </button>
+                  </div>
+                </div>
+              </div>
+            )}
+            {extraFor != null && (
+              <div
+                className="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
+                onClick={() => setExtraFor(null)}
+              >
+                <div
+                  className="bg-white p-4 rounded space-y-2"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  <div className="font-medium">Add Extra Item</div>
+                  <input
+                    className="border p-2 rounded w-full"
+                    placeholder="Name"
+                    value={extraName}
+                    onChange={(e) => setExtraName(e.target.value)}
+                  />
+                  <input
+                    type="number"
+                    className="border p-2 rounded w-full"
+                    placeholder="Amount"
+                    value={extraAmount}
+                    onChange={(e) => setExtraAmount(e.target.value)}
+                  />
+                  <div className="flex justify-end gap-2">
+                    <button className="px-4 py-1 border rounded" onClick={() => setExtraFor(null)}>
+                      Cancel
+                    </button>
+                    <button className="px-4 py-1 bg-blue-500 text-white rounded" onClick={saveExtra}>
+                      Add
                     </button>
                   </div>
                 </div>

--- a/client/src/Admin/pages/Financing/Payroll.tsx
+++ b/client/src/Admin/pages/Financing/Payroll.tsx
@@ -160,9 +160,18 @@ export default function Payroll() {
               </div>
               <ul className="text-sm list-disc pl-4">
                 {d.items.map((it, idx) => (
-                  <li key={idx}>
+                  <li key={idx} className="mb-1">
                     {it.service}, {it.date.slice(0, 10)}, ${it.amount.toFixed(2)}
                     {it.tip ? ` + ${it.tip.toFixed(2)} tip` : ''}
+                    {it.extras &&
+                      it.extras.map((ex: any, ei: number) => (
+                        <div key={ei} className="pl-4 flex items-start relative">
+                          <div className="absolute left-0 top-0 w-3 h-3 border-l border-b border-gray-400" />
+                          <span className="ml-3">
+                            {ex.name}: ${ex.amount.toFixed(2)}
+                          </span>
+                        </div>
+                      ))}
                   </li>
                 ))}
               </ul>

--- a/server/prisma/migrations/20250922120000_payroll_extras/migration.sql
+++ b/server/prisma/migrations/20250922120000_payroll_extras/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "ManualPayrollItem" ADD COLUMN "payrollItemId" INTEGER;
+
+-- AddForeignKey
+ALTER TABLE "ManualPayrollItem" ADD CONSTRAINT "ManualPayrollItem_payrollItemId_fkey" FOREIGN KEY ("payrollItemId") REFERENCES "PayrollItem"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -184,6 +184,7 @@ model PayrollItem {
   employeeId    Int
   paid          Boolean      @default(false)
   paymentId     Int?
+  extras        ManualPayrollItem[] @relation("ExtraItems")
 
   appointment   Appointment  @relation(fields: [appointmentId], references: [id], onDelete: Cascade)
   employee      Employee     @relation("EmployeePayrollItems", fields: [employeeId], references: [id], onDelete: Cascade)
@@ -209,8 +210,10 @@ model ManualPayrollItem {
   amount     Float
   paid       Boolean   @default(false)
   paymentId  Int?
+  payrollItemId Int?
   createdAt  DateTime  @default(now())
 
   employee  Employee        @relation(fields: [employeeId], references: [id], onDelete: Cascade)
   payment   EmployeePayment? @relation(fields: [paymentId], references: [id])
+  payrollItem PayrollItem?   @relation("ExtraItems", fields: [payrollItemId], references: [id])
 }


### PR DESCRIPTION
## Summary
- support additional payroll extras in DB schema
- add endpoint to add payroll extra for appointment
- update payment logic to include extras
- allow adding extras from appointment modal
- display payroll item extras in payroll list

## Testing
- `npm run build` in `client`
- `npm run build` in `server`
- `npx prisma generate` *(fails: binaries.prisma.sh blocked)*

------
https://chatgpt.com/codex/tasks/task_e_688ba5e4c148832dbc0aebf052f3aa30