### PR TITLE
Display payroll extras on appointment modal

### DIFF
--- a/client/src/Admin/pages/Calendar/types.ts
+++ b/client/src/Admin/pages/Calendar/types.ts
@@ -51,4 +51,8 @@ export interface Appointment {
   employees?: import('../Employees/components/types').Employee[]
   admin?: { id: number; name: string | null; email: string }
   createdAt?: string
+  payrollItems?: {
+    employeeId: number
+    extras: { id: number; name: string; amount: number }[]
+  }[]
 }


### PR DESCRIPTION
## Summary
- include payroll extras when fetching appointments
- return extra data from `/payroll/extra`
- show payroll extras in the appointment details modal
- keep extras in local state after adding

## Testing
- `npm run lint` *(fails: many existing errors)*
- `npm run build` in `client`
- `npm run build` in `server`
- `npm test` in `server` *(fails: no tests specified)*

------
https://chatgpt.com/codex/tasks/task_e_688baa0f44b8832d9b437cef99e71901