### PR TITLE
Update pay totals for employees

### DIFF
--- a/client/src/Admin/pages/Calendar/components/DayTimeline.tsx
+++ b/client/src/Admin/pages/Calendar/components/DayTimeline.tsx
@@ -750,12 +750,17 @@ function Day({ appointments, nowOffset, scrollRef, animating, onUpdate, onCreate
                               (selected as any).carpetRooms || 0,
                             ) /
                               (carpetIds.length || 1)))
-                        const total = base + (carpet || 0)
+                        const extras =
+                          selected.payrollItems?.find((p) => p.employeeId === e.id)?.extras || []
+                        const extrasTotal = extras.reduce((sum, ex) => sum + ex.amount, 0)
+                        const total = base + (carpet || 0) + extrasTotal
                         return (
                           <li key={e.id}>
                             {e.name} - $
                             {onCarpet && carpet ? (
-                              `${base.toFixed(2)} + ${carpet.toFixed(2)} = ${total.toFixed(2)}`
+                              `${base.toFixed(2)} + ${carpet.toFixed(2)}$${extrasTotal ? ` + ${extrasTotal.toFixed(2)}` : ''} = ${total.toFixed(2)}`
+                            ) : extrasTotal ? (
+                              `${base.toFixed(2)} + ${extrasTotal.toFixed(2)} = ${total.toFixed(2)}`
                             ) : (
                               total.toFixed(2)
                             )}

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1332,13 +1332,20 @@ app.post('/appointments/:id/send-info', async (req: Request, res: Response) => {
         : 0
 
     for (const e of appt.employees) {
+      const extras =
+        appt.payrollItems.find((p: any) => p.employeeId === e.id)?.extras || []
+      const extrasTotal = extras.reduce(
+        (sum: number, ex: any) => sum + ex.amount,
+        0,
+      )
+      const total = pay + (carpetIds.includes(e.id) ? carpetPer : 0) + extrasTotal
       const body = [
         `New appointment from Evidence Cleaning`,
         `Appointment Date: ${appt.date.toISOString().slice(0, 10)}`,
         `Appointment Time: ${appt.time}`,
         `Appointment Type: ${appt.type}`,
         `Address: ${appt.address}`,
-        `Pay: $${(pay + (carpetIds.includes(e.id) ? carpetPer : 0)).toFixed(2)}`,
+        `Pay: $${total.toFixed(2)}`,
         appt.cityStateZip ? `Instructions: ${appt.cityStateZip}` : undefined,
         note && `Note: ${note}`,
       ]


### PR DESCRIPTION
## Summary
- include extras when showing pay totals for employees in the send info modal
- show each employee's full pay including extras in SMS messages

## Testing
- `npm run build` in `server`
- `npm run lint` in `client` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_688badf08434832da5d97b4d6d1eaaa8