### PR TITLE
Fix appointment modal width on desktop

### DIFF
--- a/client/src/Admin/pages/Calendar/components/CreateAppointmentModal.tsx
+++ b/client/src/Admin/pages/Calendar/components/CreateAppointmentModal.tsx
@@ -750,7 +750,7 @@ const preserveTeamRef = useRef(false)
       onClick={handleClose}
     >
       <div
-        className="bg-white p-4 sm:p-6 rounded w-full max-w-md max-h-full overflow-y-auto overflow-x-hidden space-y-4"
+        className="bg-white p-4 sm:p-6 rounded w-full lg:w-3/5 max-w-md lg:max-w-none max-h-full overflow-y-auto overflow-x-hidden space-y-4"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex justify-between items-center">


### PR DESCRIPTION
## Summary
- widen the CreateAppointmentModal component at desktop widths

## Testing
- `npm run lint` *(fails: many existing issues)*
- `npm run build`
- `npm run build` in `server`

------
https://chatgpt.com/codex/tasks/task_e_688c27a5f594832d8f9dc7532fd6cd29