### PR TITLE
Make nav sticky on desktop

### DIFF
--- a/client/src/Admin/AdminDashboard.tsx
+++ b/client/src/Admin/AdminDashboard.tsx
@@ -21,7 +21,7 @@ export default function AdminDashboard({ onLogout }: Props) {
 
   return (
     <div className="min-h-screen bg-gray-100 text-gray-900">
-      <nav className="bg-white shadow md:mb-4 fixed bottom-0 w-full md:static z-10">
+      <nav className="bg-white shadow md:mb-4 fixed bottom-0 w-full md:sticky md:top-0 z-10">
         <ul className="flex flex-wrap justify-around p-2 text-sm">
           <li><Link className="px-2 py-1" to="/dashboard">Home</Link></li>
           <li><Link className="px-2 py-1" to="/dashboard/calendar">Calendar</Link></li>


### PR DESCRIPTION
## Summary
- ensure the dashboard navigation sticks to the top on desktop screens

## Testing
- `npm run lint` *(fails: no-unused-vars and other lint errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688c2a9518f0832da11e63dbc4d3a007