### PR TITLE
Improve Daily View styling

### DIFF
--- a/client/src/Admin/pages/Calendar/components/DayTimeline.tsx
+++ b/client/src/Admin/pages/Calendar/components/DayTimeline.tsx
@@ -332,8 +332,8 @@ function Day({ appointments, nowOffset, scrollRef, animating, onUpdate, onCreate
         {/* appointment blocks */}
         {layout.map((l, idx) => {
           const top = (l.start / 60) * 84
-          const height = ((l.end - l.start) / 60) * 84 - 2
-          const leftStyle = `calc(${dividerPx}px + ${l.lane} * (40vw + ${LANE_GAP}px))`
+          const height = ((l.end - l.start) / 60) * 84
+          const leftStyle = `calc(${dividerPx}px + 4px + ${l.lane} * (40vw + ${LANE_GAP}px))`
           // 1) pull out the YYYY-MM-DD as numbers, ignoring any timezone
           const [year, month, day] = l.appt.date.slice(0, 10).split('-').map(Number);
 
@@ -354,7 +354,7 @@ function Day({ appointments, nowOffset, scrollRef, animating, onUpdate, onCreate
           return (
             <div
               key={l.appt.id ?? idx}
-              className={`absolute border rounded text-xs overflow-hidden cursor-pointer ${bg}`}
+              className={`absolute border rounded-md text-xs overflow-hidden cursor-pointer ${bg}`}
               style={{ top, left: leftStyle, width: apptWidth, height, zIndex: 10 }}
               onClick={() => {
                 setSelected(l.appt)


### PR DESCRIPTION
## Summary
- round appointment blocks
- adjust appointment block height so bottom border shows
- add small gap from the timeline divider

## Testing
- `npm run lint` *(fails: react-refresh/only-export-components, etc.)*
- `npm run build` in `client`
- `npm run build` in `server`


------
https://chatgpt.com/codex/tasks/task_e_688c2df5568c832d8096a9a17c6e5ce1