### PR TITLE
Fix appointment block spacing

### DIFF
--- a/client/src/Admin/pages/Calendar/components/DayTimeline.tsx
+++ b/client/src/Admin/pages/Calendar/components/DayTimeline.tsx
@@ -332,8 +332,8 @@ function Day({ appointments, nowOffset, scrollRef, animating, onUpdate, onCreate
         {/* appointment blocks */}
         {layout.map((l, idx) => {
           const top = (l.start / 60) * 84
-          const height = ((l.end - l.start) / 60) * 84
-          const leftStyle = `calc(${dividerPx}px + 4px + ${l.lane} * (40vw + ${LANE_GAP}px))`
+          const height = ((l.end - l.start) / 60) * 84 - 2
+          const leftStyle = `calc(${dividerPx}px + 8px + ${l.lane} * (40vw + ${LANE_GAP}px))`
           // 1) pull out the YYYY-MM-DD as numbers, ignoring any timezone
           const [year, month, day] = l.appt.date.slice(0, 10).split('-').map(Number);
 


### PR DESCRIPTION
## Summary
- adjust left padding and height for calendar appointment blocks

## Testing
- `npm run lint` *(fails: many eslint errors)*
- `npm test` in `server` *(fails: no test specified)*
- `npm test` in `client` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688c30481af0832d9809e7c8c725c25d