### PR TITLE
Add appointment link to calendar

### DIFF
--- a/client/src/Admin/components/AppointmentsSection.tsx
+++ b/client/src/Admin/components/AppointmentsSection.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
+import { Link } from 'react-router-dom'
 import type { Appointment } from '../pages/Calendar/types'
 import { fetchJson } from "../../api"
 
@@ -56,18 +57,23 @@ export default function AppointmentsSection({ url }: Props) {
       <h3 className="text-lg font-semibold mb-2">Appointments</h3>
       <ul className="space-y-2">
         {items.map((a) => (
-          <li key={a.id} className="border rounded p-2 bg-white shadow">
-            <div className="font-medium">
-              {a.date.slice(0, 10)} {formatTime(a.time)} - {a.type}
-            </div>
-            <div className="text-sm text-gray-600">
-              {a.client?.name || ''} {a.address}
-            </div>
-            {a.employees && a.employees.length > 0 && (
-              <div className="text-sm text-gray-600">
-                {a.employees.map((e) => e.name).join(', ')}
+          <li key={a.id} className="border rounded bg-white shadow">
+            <Link
+              to={`/dashboard/calendar?date=${a.date.slice(0, 10)}&appt=${a.id}`}
+              className="block p-2"
+            >
+              <div className="font-medium">
+                {a.date.slice(0, 10)} {formatTime(a.time)} - {a.type}
               </div>
-            )}
+              <div className="text-sm text-gray-600">
+                {a.client?.name || ''} {a.address}
+              </div>
+              {a.employees && a.employees.length > 0 && (
+                <div className="text-sm text-gray-600">
+                  {a.employees.map((e) => e.name).join(', ')}
+                </div>
+              )}
+            </Link>
           </li>
         ))}
       </ul>

--- a/client/src/Admin/pages/Calendar/components/DayTimeline.tsx
+++ b/client/src/Admin/pages/Calendar/components/DayTimeline.tsx
@@ -46,12 +46,13 @@ interface DayProps {
   nowOffset: number | null
   scrollRef?: Ref<HTMLDivElement>
   animating: boolean
+  initialApptId?: number
   onUpdate?: (a: Appointment) => void
   onCreate?: (appt: Appointment, status: Appointment['status']) => void
   onEdit?: (appt: Appointment) => void
 }
 
-function Day({ appointments, nowOffset, scrollRef, animating, onUpdate, onCreate, onEdit }: DayProps) {
+function Day({ appointments, nowOffset, scrollRef, animating, initialApptId, onUpdate, onCreate, onEdit }: DayProps) {
   const { alert, confirm } = useModal()
   const navigate = useNavigate()
   const [selected, setSelected] = useState<Appointment | null>(null)
@@ -71,6 +72,18 @@ function Day({ appointments, nowOffset, scrollRef, animating, onUpdate, onCreate
   const [extraFor, setExtraFor] = useState<number | null>(null)
   const [extraName, setExtraName] = useState('')
   const [extraAmount, setExtraAmount] = useState('')
+
+  const initialShown = useRef(false)
+
+  useEffect(() => {
+    if (!initialShown.current && initialApptId && appointments.length) {
+      const match = appointments.find((a) => a.id === initialApptId)
+      if (match) {
+        setSelected(match)
+        initialShown.current = true
+      }
+    }
+  }, [initialApptId, appointments])
 
   const updateAppointment = async (data: {
     status?: Appointment['status']
@@ -841,6 +854,7 @@ interface Props {
   appointments: Appointment[]
   prevAppointments: Appointment[]
   nextAppointments: Appointment[]
+  initialApptId?: number
   onUpdate?: (a: Appointment) => void
   onCreate?: (appt: Appointment, status: Appointment['status']) => void
   onEdit?: (appt: Appointment) => void
@@ -853,6 +867,7 @@ export default function DayTimeline({
   appointments,
   prevAppointments,
   nextAppointments,
+  initialApptId,
   onUpdate,
   onCreate,
   onEdit,
@@ -968,6 +983,7 @@ export default function DayTimeline({
           nowOffset={nowOffset}
           scrollRef={currentDayRef}
           animating={animating}
+          initialApptId={initialApptId}
           onUpdate={onUpdate}
           onCreate={onCreate}
           onEdit={onEdit}

--- a/client/src/Admin/pages/Calendar/index.tsx
+++ b/client/src/Admin/pages/Calendar/index.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { useLocation } from 'react-router-dom'
 import { API_BASE_URL, fetchJson } from '../../../api'
 import MonthSelector from './components/MonthSelector'
 import WeekSelector from './components/WeekSelector'
@@ -20,7 +21,16 @@ function addMonths(date: Date, months: number) {
 }
 
 export default function Calendar() {
+  const location = useLocation()
+  const params = new URLSearchParams(location.search)
+  const queryDate = params.get('date')
+  const queryAppt = params.get('appt')
+
   const [selected, setSelected] = useState(() => {
+    if (queryDate) {
+      const d = new Date(queryDate)
+      if (!isNaN(d.getTime())) return d
+    }
     const stored = localStorage.getItem('calendarSelectedDate')
     if (stored) {
       try {
@@ -272,6 +282,7 @@ export default function Calendar() {
           appointments={appointments.current}
           prevAppointments={appointments.prev}
           nextAppointments={appointments.next}
+          initialApptId={queryAppt ? Number(queryAppt) : undefined}
           onUpdate={handleUpdate}
           onCreate={(appt, status) => handleCreateFrom(appt, status)}
           onEdit={handleEdit}


### PR DESCRIPTION
## Summary
- link appointments list items to the calendar page
- accept initial appointment id in calendar timeline
- open selected appointment automatically when passed via query params

## Testing
- `npm --prefix client run lint` *(fails: many errors)*
- `npm --prefix server run build`
- `npm --prefix client run build`


------
https://chatgpt.com/codex/tasks/task_e_688d5e17ed3c832db376605bb526e710