### PR TITLE
Add client source tracking and cancel option

### DIFF
--- a/client/src/Admin/pages/Clients/components/ClientForm.tsx
+++ b/client/src/Admin/pages/Clients/components/ClientForm.tsx
@@ -13,14 +13,14 @@ export default function ClientForm() {
   const isNew = id === undefined
   const storageKey = `clientForm-${id || 'new'}`
   const [data, setData] = useState<Client>(() =>
-    loadFormPersistence(storageKey, { name: '', number: '', notes: '', disabled: false }),
+    loadFormPersistence(storageKey, { name: '', number: '', from: '', notes: '', disabled: false }),
   )
   useFormPersistence(storageKey, data)
 
   useEffect(() => {
     if (!isNew) {
       fetchJson(`${API_BASE_URL}/clients/${id}`)
-        .then((d) => setData(d))
+        .then((d) => setData({ from: '', ...d }))
         .catch((err) => console.error(err))
     }
   }, [id, isNew])
@@ -33,7 +33,9 @@ export default function ClientForm() {
   }
 
   const handleChange = (
-    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+    e: React.ChangeEvent<
+      HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
+    >,
   ) => {
     const updated = { ...data, [e.target.name]: e.target.value }
     persist(updated)
@@ -59,6 +61,7 @@ export default function ClientForm() {
     const payload = {
       name: data.name,
       number: data.number.length === 10 ? '1' + data.number : data.number,
+      from: data.from,
       notes: data.notes,
       disabled: data.disabled ?? false,
     }
@@ -124,6 +127,28 @@ export default function ClientForm() {
         />
       </div>
       <div>
+        <label htmlFor="client-from" className="block text-sm">
+          From <span className="text-red-500">*</span>
+        </label>
+        <select
+          id="client-from"
+          name="from"
+          value={data.from}
+          onChange={handleChange}
+          required
+          className="w-full border p-2 rounded"
+        >
+          <option value="" disabled>
+            Select source
+          </option>
+          <option value="Yelp">Yelp</option>
+          <option value="Form">Form</option>
+          <option value="Call">Call</option>
+          <option value="Rita">Rita</option>
+          <option value="Marcelo">Marcelo</option>
+        </select>
+      </div>
+      <div>
         <label htmlFor="client-notes" className="block text-sm">Notes</label>
         <textarea
           id="client-notes"
@@ -146,6 +171,16 @@ export default function ClientForm() {
       <div className="flex gap-2">
         <button className="bg-blue-500 text-white px-4 py-2 rounded" type="submit">
           Save
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            clearFormPersistence(storageKey)
+            navigate('..')
+          }}
+          className="bg-gray-300 px-4 py-2 rounded"
+        >
+          Cancel
         </button>
         {!isNew && (
           <button

--- a/client/src/Admin/pages/Clients/components/types.ts
+++ b/client/src/Admin/pages/Clients/components/types.ts
@@ -2,6 +2,7 @@ export interface Client {
   id?: number
   name: string
   number: string
+  from: string
   notes?: string
   disabled?: boolean
 }

--- a/server/prisma/migrations/20250922130000_add_client_from/migration.sql
+++ b/server/prisma/migrations/20250922130000_add_client_from/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Client" ADD COLUMN "from" TEXT;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -22,6 +22,7 @@ model Client {
   id                   Int                    @id @default(autoincrement())
   name                 String                 @unique
   number               String
+  from                 String?
   notes                String?
   disabled             Boolean                @default(false)
   appointments         Appointment[]

--- a/server/prisma/seed.ts
+++ b/server/prisma/seed.ts
@@ -23,10 +23,10 @@ async function main() {
   })
 
   const john = await prisma.client.create({
-    data: { name: 'John Doe', number: '5551111111' },
+    data: { name: 'John Doe', number: '5551111111', from: 'Yelp' },
   })
   const jane = await prisma.client.create({
-    data: { name: 'Jane Smith', number: '5552222222' },
+    data: { name: 'Jane Smith', number: '5552222222', from: 'Call' },
   })
 
   const empOne = await prisma.employee.create({

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -423,21 +423,22 @@ app.get('/clients', async (req: Request, res: Response) => {
 
 app.post('/clients', async (req: Request, res: Response) => {
   try {
-    const { name, number, notes, disabled } = req.body as {
+    const { name, number, from, notes, disabled } = req.body as {
       name?: string
       number?: string
+      from?: string
       notes?: string
       disabled?: boolean
     }
-    if (!name || !number) {
-      return res.status(400).json({ error: 'Name and number are required' })
+    if (!name || !number || !from) {
+      return res.status(400).json({ error: 'Name, number and from are required' })
     }
     const normalized = normalizePhone(number)
     if (!normalized) {
       return res.status(400).json({ error: 'Number must be 10 or 11 digits' })
     }
     const client = await prisma.client.create({
-      data: { name, number: normalized, notes, disabled: disabled ?? false },
+      data: { name, number: normalized, from, notes, disabled: disabled ?? false },
     })
     res.json(client)
   } catch (e: any) {
@@ -463,9 +464,10 @@ app.get('/clients/:id', async (req: Request, res: Response) => {
 app.put('/clients/:id', async (req: Request, res: Response) => {
   const id = parseInt(req.params.id, 10)
   try {
-    const { name, number, notes, disabled } = req.body as {
+    const { name, number, from, notes, disabled } = req.body as {
       name?: string
       number?: string
+      from?: string
       notes?: string
       disabled?: boolean
     }
@@ -478,6 +480,7 @@ app.put('/clients/:id', async (req: Request, res: Response) => {
       }
       data.number = normalized
     }
+    if (from !== undefined) data.from = from
     if (notes !== undefined) data.notes = notes
     if (disabled !== undefined) data.disabled = disabled
     const client = await prisma.client.update({ where: { id }, data })


### PR DESCRIPTION
## Summary
- require a "From" source when creating or editing a client
- allow admins to cancel client edits
- persist client source in database schema and seed data

## Testing
- `npm test` *(server)*
- `npm run build` *(server)*
- `npm test` *(client)*
- `npm run build` *(client)*

------
https://chatgpt.com/codex/tasks/task_e_688e7ac4d310832dbcc7f4ccc2e1fea0