### PR TITLE
feat: enable mobile call or text from appointment

### DIFF
--- a/client/src/Admin/pages/Calendar/components/CreateAppointmentModal.tsx
+++ b/client/src/Admin/pages/Calendar/components/CreateAppointmentModal.tsx
@@ -130,6 +130,13 @@ export default function CreateAppointmentModal({ onClose, onCreated, initialClie
   )
   const [noTeam, setNoTeam] = useState<boolean>(persisted.noTeam ?? false)
 
+  const [showPhoneActions, setShowPhoneActions] = useState(false)
+  const isMobile =
+    typeof navigator !== 'undefined' && /iPhone|iPad|iPod|Android/i.test(navigator.userAgent)
+  const handlePhoneClick = () => {
+    if (isMobile) setShowPhoneActions((prev) => !prev)
+  }
+
   const selectedTemplateData = selectedTemplate
     ? templates.find((tt) => tt.id === selectedTemplate)
     : null
@@ -788,7 +795,38 @@ const preserveTeamRef = useRef(false)
               </button>
             </div>
             <div className="text-sm border rounded p-2 mt-1 space-y-1">
-              <div>Number: {formatPhone(selectedClient.number)}</div>
+              <div>
+                Number:{' '}
+                {isMobile ? (
+                  <button
+                    type="button"
+                    className="underline text-blue-500"
+                    onClick={handlePhoneClick}
+                  >
+                    {formatPhone(selectedClient.number)}
+                  </button>
+                ) : (
+                  formatPhone(selectedClient.number)
+                )}
+              </div>
+              {isMobile && showPhoneActions && (
+                <div className="flex gap-2">
+                  <a
+                    href={`tel:${selectedClient.number}`}
+                    className="px-2 py-1 bg-blue-500 text-white rounded"
+                    onClick={() => setShowPhoneActions(false)}
+                  >
+                    Call
+                  </a>
+                  <a
+                    href={`sms:${selectedClient.number}`}
+                    className="px-2 py-1 bg-blue-500 text-white rounded"
+                    onClick={() => setShowPhoneActions(false)}
+                  >
+                    Text
+                  </a>
+                </div>
+              )}
               {selectedClient.notes && <div>Notes: {selectedClient.notes}</div>}
             </div>
           </div>

--- a/client/src/Admin/pages/Calendar/components/DayTimeline.tsx
+++ b/client/src/Admin/pages/Calendar/components/DayTimeline.tsx
@@ -73,8 +73,19 @@ function Day({ appointments, nowOffset, scrollRef, animating, initialApptId, onU
   const [extraFor, setExtraFor] = useState<number | null>(null)
   const [extraName, setExtraName] = useState('')
   const [extraAmount, setExtraAmount] = useState('')
+  const [showPhoneActions, setShowPhoneActions] = useState(false)
+  const isMobile =
+    typeof navigator !== 'undefined' &&
+    /iPhone|iPad|iPod|Android/i.test(navigator.userAgent)
+  const handlePhoneClick = () => {
+    if (isMobile) setShowPhoneActions((prev) => !prev)
+  }
 
   const initialShown = useRef(false)
+
+  useEffect(() => {
+    setShowPhoneActions(false)
+  }, [selected])
 
   useEffect(() => {
     if (!initialShown.current && initialApptId && appointments.length) {
@@ -414,7 +425,39 @@ function Day({ appointments, nowOffset, scrollRef, animating, initialApptId, onU
                   {selected.client ? selected.client.name : 'Client'}
                 </h4>
                 {selected.client?.number && (
-                  <div className="text-sm text-gray-600">{formatPhone(selected.client.number)}</div>
+                  <>
+                    <div className="text-sm text-gray-600">
+                      {isMobile ? (
+                        <button
+                          type="button"
+                          className="underline text-blue-500"
+                          onClick={handlePhoneClick}
+                        >
+                          {formatPhone(selected.client.number)}
+                        </button>
+                      ) : (
+                        formatPhone(selected.client.number)
+                      )}
+                    </div>
+                    {isMobile && showPhoneActions && (
+                      <div className="flex gap-2 mt-1">
+                        <a
+                          href={`tel:${selected.client.number}`}
+                          className="px-2 py-1 bg-blue-500 text-white rounded"
+                          onClick={() => setShowPhoneActions(false)}
+                        >
+                          Call
+                        </a>
+                        <a
+                          href={`sms:${selected.client.number}`}
+                          className="px-2 py-1 bg-blue-500 text-white rounded"
+                          onClick={() => setShowPhoneActions(false)}
+                        >
+                          Text
+                        </a>
+                      </div>
+                    )}
+                  </>
                 )}
               </div>
               <div className="flex gap-2">


### PR DESCRIPTION
## Summary
- allow tapping a client's phone number in the appointment modal to reveal Call and Text options on mobile devices
- enable the same Call and Text actions when viewing an appointment's details

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: 111 problems)


------
https://chatgpt.com/codex/tasks/task_e_688e8645fcb0832d9fbc8b0e9c53f05c