### PR TITLE
fix: highlight done recurring cards

### DIFF
--- a/client/src/Admin/pages/Home/HomePanel.tsx
+++ b/client/src/Admin/pages/Home/HomePanel.tsx
@@ -27,7 +27,7 @@ export default function HomePanel({ title, cards, className = '' }: Props) {
           {cards.map((c) => (
             <li
               key={c.key}
-              className={`bg-white rounded shadow p-3 flex justify-between items-center ${c.done ? 'bg-green-100' : ''}`}
+              className={`rounded shadow p-3 flex justify-between items-center ${c.done ? 'bg-green-100' : 'bg-white'}`}
             >
               <div className="flex items-center gap-2">
                 {c.onToggleDone && (


### PR DESCRIPTION
## Summary
- ensure completed upcoming recurring cards render with a green background

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: 111 problems)


------
https://chatgpt.com/codex/tasks/task_e_688e928ba30c832d9910e4dd1955799e