### PR TITLE
Show client source in appointment modals

### DIFF
--- a/client/src/Admin/pages/Calendar/components/CreateAppointmentModal.tsx
+++ b/client/src/Admin/pages/Calendar/components/CreateAppointmentModal.tsx
@@ -827,6 +827,7 @@ const preserveTeamRef = useRef(false)
                   </a>
                 </div>
               )}
+              {selectedClient.from && <div>From: {selectedClient.from}</div>}
               {selectedClient.notes && <div>Notes: {selectedClient.notes}</div>}
             </div>
           </div>
@@ -916,6 +917,7 @@ const preserveTeamRef = useRef(false)
                 >
                   <div className="font-medium">{c.name}</div>
                   <div className="text-sm text-gray-600">{formatPhone(c.number)}</div>
+                  <div className="text-sm text-gray-600">From: {c.from}</div>
                 </li>
               ))}
             </ul>

--- a/client/src/Admin/pages/Calendar/components/DayTimeline.tsx
+++ b/client/src/Admin/pages/Calendar/components/DayTimeline.tsx
@@ -459,6 +459,9 @@ function Day({ appointments, nowOffset, scrollRef, animating, initialApptId, onU
                     )}
                   </>
                 )}
+                {selected.client?.from && (
+                  <div className="text-sm text-gray-600">From: {selected.client.from}</div>
+                )}
               </div>
               <div className="flex gap-2">
                 <button


### PR DESCRIPTION
## Summary
- Display client "from" source in appointment detail modal
- Show client source when selecting a client and in search list in the new appointment modal

## Testing
- `npm run lint` *(fails: 111 problems, 93 errors, 18 warnings)*


------
https://chatgpt.com/codex/tasks/task_e_688e952b2190832d9d5aa080c2d8f4f2