### PR TITLE
feat: add other items to invoices

### DIFF
--- a/server/prisma/migrations/20250923000000_invoice_other_items/migration.sql
+++ b/server/prisma/migrations/20250923000000_invoice_other_items/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Invoice" ADD COLUMN "otherItems" JSONB;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -177,6 +177,7 @@ model Invoice {
   discount    Float?
   taxPercent  Float?
   comment     String?
+  otherItems  Json?
   paid        Boolean  @default(true)
   total       Float
   createdAt   DateTime @default(now())


### PR DESCRIPTION
## Summary
- support adding custom "other" items with name and price when creating invoices
- persist extra items on backend and include them in totals and PDFs

## Testing
- `npm test`
- `npm test` (server)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688ec543c408832db624c55ddc49becb