### PR TITLE
Fix invoice modal closing logic

### DIFF
--- a/client/src/Admin/pages/Financing/Invoice.tsx
+++ b/client/src/Admin/pages/Financing/Invoice.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Link, useLocation } from 'react-router-dom'
 import { API_BASE_URL, fetchJson } from '../../../api'
 import type { Appointment } from '../Calendar/types'
@@ -38,9 +38,15 @@ export default function Invoice() {
         if (match) setSelected(match)
       }
     }
-  }, [initialAppt, appointments, selected])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialAppt, appointments])
 
+  const initialized = useRef(false)
   useEffect(() => {
+    if (!initialized.current) {
+      initialized.current = true
+      return
+    }
     if (selected) {
       localStorage.setItem('createInvoiceSelected', String(selected.id))
     } else {


### PR DESCRIPTION
## Summary
- ensure Create Invoice modal closes when requested
- keep modal open across refreshes until explicitly closed

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 105 problems)

------
https://chatgpt.com/codex/tasks/task_e_688eea55dcdc832dbb16b1958bd220bc