### PR TITLE
Improve Google Drive credential parsing

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -21,4 +21,8 @@ TWILIO_AUTH_TOKEN=your-twilio-auth-token
 TWILIO_FROM_NUMBER=+10005551234
 
 # Google Drive API
+# JSON credentials for a Google service account. Supply the value as raw JSON,
+# a base64 string (useful on hosts like Railway that don't support multiline
+# secrets) or a path to the JSON file. If parsing fails the value is treated as
+# a plain API key.
 GOOGLE_DRIVE_API_KEY=your-google-drive-api-key

--- a/server/README.md
+++ b/server/README.md
@@ -6,6 +6,16 @@ The database connection string is configured via `.env` and a `docker-compose.ym
 
 To enable Google authentication set `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_REDIRECT_URI` and `ADMIN_EMAILS` in your `.env` file. Emails listed in `ADMIN_EMAILS` (comma separated) will be treated as admins when logging in.
 
+## Google Drive uploads
+
+Invoices are uploaded to Google Drive using a service account. Provide the credentials via the `GOOGLE_DRIVE_API_KEY` environment variable. The variable may contain the raw JSON, a base64-encoded JSON string, or a path to the JSON file. Hosts like Railway don't allow multiline secrets, so base64 is often the simplest approach:
+
+```bash
+GOOGLE_DRIVE_API_KEY=$(base64 -w0 service-account.json)
+```
+
+At runtime the server automatically detects and parses these formats. If parsing fails the value is used as a plain API key.
+
 ## Local HTTPS
 
 The server can also run over HTTPS in development. Generate a self-signed

--- a/server/src/drive.ts
+++ b/server/src/drive.ts
@@ -1,5 +1,6 @@
 import { google } from 'googleapis'
 import { Readable } from 'stream'
+import { readFileSync, existsSync } from 'fs'
 import type { Invoice } from '@prisma/client'
 
 async function ensureFolder(drive: any, name: string, parentId?: string): Promise<string> {
@@ -19,37 +20,42 @@ async function ensureFolder(drive: any, name: string, parentId?: string): Promis
   return folder.data.id!
 }
 
-export async function uploadInvoiceToDrive(inv: Invoice, pdf: Buffer) {
-  const credentials = process.env.GOOGLE_DRIVE_API_KEY
-  if (!credentials) throw new Error('GOOGLE_DRIVE_API_KEY not set')
-
-  // Credentials are expected to be a JSON string but some environments may
-  // provide them base64-encoded (sometimes in URL-safe format or without
-  // padding). Attempt to parse the value directly and fall back to a
-  // normalized base64 decode so misconfigured credentials do not throw a
-  // cryptic JSON error.
-  let parsedCreds: any
+function loadCreds(value: string) {
   try {
-    parsedCreds = JSON.parse(credentials)
-  } catch {
-    try {
-      const normalized = credentials
-        .replace(/\s+/g, '')
-        .replace(/-/g, '+')
-        .replace(/_/g, '/')
-      const pad = normalized.length % 4
-      const padded = pad ? normalized + '='.repeat(4 - pad) : normalized
-      const decoded = Buffer.from(padded, 'base64').toString('utf8')
-      parsedCreds = JSON.parse(decoded)
-    } catch {
-      throw new Error('GOOGLE_DRIVE_API_KEY must be valid JSON or base64-encoded JSON')
-    }
+    return JSON.parse(value)
+  } catch {}
+
+  try {
+    const normalized = value.replace(/\s+/g, '').replace(/-/g, '+').replace(/_/g, '/')
+    const pad = normalized.length % 4
+    const padded = pad ? normalized + '='.repeat(4 - pad) : normalized
+    const decoded = Buffer.from(padded, 'base64').toString('utf8')
+    return JSON.parse(decoded)
+  } catch {}
+
+  if (existsSync(value)) {
+    const file = readFileSync(value, 'utf8')
+    return JSON.parse(file)
   }
 
-  const auth = new google.auth.GoogleAuth({
-    credentials: parsedCreds,
-    scopes: ['https://www.googleapis.com/auth/drive.file'],
-  })
+  return null
+}
+
+export async function uploadInvoiceToDrive(inv: Invoice, pdf: Buffer) {
+  const key = process.env.GOOGLE_DRIVE_API_KEY
+  if (!key) throw new Error('GOOGLE_DRIVE_API_KEY not set')
+
+  // Environments like Railway cannot store multi-line secrets. Allow the key to
+  // be provided as raw JSON, base64-encoded JSON or a path to the JSON file.
+  // If none of these formats parse, treat it as a plain API key string.
+  const parsedCreds = loadCreds(key)
+
+  const auth = parsedCreds
+    ? new google.auth.GoogleAuth({
+        credentials: parsedCreds,
+        scopes: ['https://www.googleapis.com/auth/drive.file'],
+      })
+    : key
   const drive = google.drive({ version: 'v3', auth })
 
   const serviceDate = new Date(inv.serviceDate)


### PR DESCRIPTION
## Summary
- centralize Google Drive credential parsing into helper to read JSON, base64 or file paths and fall back to API keys
- document providing base64 service account credentials for hosts like Railway in `.env.example` and README

## Testing
- `npm test` (fails: no test specified)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688efa561b48832dab67bd9b4c74ef2e