### PR TITLE
fix: upload invoices into yearly drive folders

### DIFF
--- a/server/src/drive.ts
+++ b/server/src/drive.ts
@@ -36,8 +36,7 @@ export async function uploadInvoiceToDrive(inv: Invoice, pdf: Buffer) {
   const year = String(serviceDate.getFullYear())
   const month = String(serviceDate.getMonth() + 1).padStart(2, '0')
 
-  const driveFolder = await ensureFolder(drive, 'drive')
-  const invoicesFolder = await ensureFolder(drive, 'invoices', driveFolder)
+  const invoicesFolder = await ensureFolder(drive, 'invoices')
   const yearFolder = await ensureFolder(drive, year, invoicesFolder)
   const monthFolder = await ensureFolder(drive, month, yearFolder)
 


### PR DESCRIPTION
## Summary
- upload invoice PDFs directly into the `invoices` Google Drive folder
- ensure year and month folders exist before saving

## Testing
- `npm test` (server) *(fails: Error: no test specified)*
- `npm test` (client) *(fails: Missing script: "test")*
- `npm run build` (server)


------
https://chatgpt.com/codex/tasks/task_e_689032ff393c832dab1fd0798790e373