### PR TITLE
Require size for appointment templates

### DIFF
--- a/client/src/Admin/pages/Calendar/components/CreateAppointmentModal.tsx
+++ b/client/src/Admin/pages/Calendar/components/CreateAppointmentModal.tsx
@@ -95,6 +95,13 @@ export default function CreateAppointmentModal({ onClose, onCreated, initialClie
     ...(persisted.templateForm || {}),
   })
 
+  const isTemplateReady =
+    templateForm.templateName.trim() !== '' &&
+    templateForm.address.trim() !== '' &&
+    templateForm.price !== '' &&
+    templateForm.size !== '' &&
+    (!templateForm.carpetEnabled || parseInt(templateForm.carpetRooms, 10) >= 1)
+
   const [date, setDate] = useState<string>(persisted.date ?? '')
   const [time, setTime] = useState<string>(persisted.time ?? '')
 
@@ -592,6 +599,7 @@ const preserveTeamRef = useRef(false)
     if (!templateForm.templateName.trim()) missing.push('template name')
     if (!templateForm.address.trim()) missing.push('address')
     if (templateForm.price === '') missing.push('price')
+    if (!templateForm.size) missing.push('size')
     if (templateForm.carpetEnabled) {
       const rooms = parseInt(templateForm.carpetRooms, 10)
       if (isNaN(rooms) || rooms < 1) {
@@ -606,7 +614,7 @@ const preserveTeamRef = useRef(false)
       clientId: selectedClient.id,
       templateName: templateForm.templateName,
       type: templateForm.type,
-      size: templateForm.size || undefined,
+      size: templateForm.size,
       address: templateForm.address,
       price: parseFloat(templateForm.price),
       notes: templateForm.notes || undefined,
@@ -1083,8 +1091,9 @@ const preserveTeamRef = useRef(false)
                   </button>
                   <button
                     type="button"
-                    className="bg-blue-500 text-white px-3 py-2 rounded"
+                    className="bg-blue-500 text-white px-3 py-2 rounded disabled:opacity-50"
                     onClick={createTemplate}
+                    disabled={!isTemplateReady}
                   >
                     Save Template
                   </button>
@@ -1380,6 +1389,7 @@ const preserveTeamRef = useRef(false)
           <button
             className="bg-blue-500 text-white px-6 py-2 rounded disabled:opacity-50"
             disabled={
+              showNewTemplate ||
               !selectedTemplate ||
               !date ||
               !time ||

--- a/client/src/Admin/pages/Calendar/types.ts
+++ b/client/src/Admin/pages/Calendar/types.ts
@@ -2,7 +2,7 @@ export interface AppointmentTemplate {
   id?: number
   templateName: string
   type: 'STANDARD' | 'DEEP' | 'MOVE_IN_OUT'
-  size?: string
+  size: string
   address: string
   price: number
   clientId: number

--- a/server/prisma/migrations/20250801090000_template_size_required/migration.sql
+++ b/server/prisma/migrations/20250801090000_template_size_required/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "AppointmentTemplate" ALTER COLUMN "size" SET NOT NULL;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -92,7 +92,7 @@ model AppointmentTemplate {
   id                Int                @id @default(autoincrement())
   templateName      String
   type              AppointmentType
-  size              String?
+  size              String
   address           String
   cityStateZip      String?
   price             Float

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -772,6 +772,7 @@ app.post('/appointment-templates', async (req: Request, res: Response) => {
       !clientId ||
       !templateName ||
       !type ||
+      !size ||
       !address ||
       price === undefined
     ) {


### PR DESCRIPTION
## Summary
- enforce size requirement when creating appointment templates on server and client
- make `AppointmentTemplate.size` mandatory in Prisma schema with migration
- validate template form to require size and adjust types
- disable saving or creating appointments until template info is complete

## Testing
- `npm test` (server) *(fails: Error: no test specified)*
- `npm run build` (server)
- `npm test` (client) *(fails: Missing script: "test")*
- `npm run build` (client)


------
https://chatgpt.com/codex/tasks/task_e_68929654e1c8832d8c953b605ec50504