### PR TITLE
Enhance payroll editing and extras handling

### DIFF
--- a/client/src/Admin/pages/Calendar/components/DayTimeline.tsx
+++ b/client/src/Admin/pages/Calendar/components/DayTimeline.tsx
@@ -237,7 +237,9 @@ function Day({ appointments, nowOffset, scrollRef, animating, initialApptId, onU
             item = { employeeId: extraFor, extras: [] }
             items.push(item)
           }
-          item.extras = [...item.extras, { id: ex.id, name: ex.name, amount: ex.amount }]
+          if (!item.extras.some((e) => e.id === ex.id)) {
+            item.extras = [...item.extras, { id: ex.id, name: ex.name, amount: ex.amount }]
+          }
           return { ...curr, payrollItems: items }
         })
       }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1796,6 +1796,19 @@ app.post('/payroll/manual', async (req: Request, res: Response) => {
   res.json({ id: item.id })
 })
 
+app.put('/payroll/manual/:id', async (req: Request, res: Response) => {
+  const id = Number(req.params.id)
+  const { name, amount } = req.body as { name?: string; amount?: number }
+  if (!id || amount == null) {
+    return res.status(400).json({ error: 'id and amount required' })
+  }
+  const item = await prisma.manualPayrollItem.update({
+    where: { id },
+    data: { name: name || 'Other', amount },
+  })
+  res.json({ id: item.id, name: item.name, amount: item.amount })
+})
+
 app.post('/payroll/extra', async (req: Request, res: Response) => {
   const { appointmentId, employeeId, name, amount } = req.body as {
     appointmentId?: number


### PR DESCRIPTION
## Summary
- prevent duplicate extras when adding
- allow selecting payroll items with automatic inclusion of extras and show item totals
- add modal to edit payroll items and their extras
- support editing manual payroll items via new API endpoint

## Testing
- `npm test` (server)
- `npm test` (client, fails: Missing script)


------
https://chatgpt.com/codex/tasks/task_e_6895a97e5630832db781df7a6a7902e3