### PR TITLE
Enable managing payroll subitems in edit modal

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1810,19 +1810,22 @@ app.put('/payroll/manual/:id', async (req: Request, res: Response) => {
 })
 
 app.post('/payroll/extra', async (req: Request, res: Response) => {
-  const { appointmentId, employeeId, name, amount } = req.body as {
+  const { appointmentId, payrollItemId, employeeId, name, amount } = req.body as {
     appointmentId?: number
+    payrollItemId?: number
     employeeId?: number
     name?: string
     amount?: number
   }
-  if (!appointmentId || !employeeId || amount == null) {
+  if ((!appointmentId && !payrollItemId) || !employeeId || amount == null) {
     return res
       .status(400)
-      .json({ error: 'appointmentId, employeeId and amount required' })
+      .json({ error: 'appointmentId or payrollItemId, employeeId and amount required' })
   }
   const payrollItem = await prisma.payrollItem.findFirst({
-    where: { appointmentId, employeeId },
+    where: payrollItemId
+      ? { id: payrollItemId, employeeId }
+      : { appointmentId: appointmentId!, employeeId },
   })
   if (!payrollItem) {
     return res.status(404).json({ error: 'payroll item not found' })


### PR DESCRIPTION
## Summary
- allow backend to create payroll extras by `payrollItemId`
- add ability to create subitems in payroll edit modal
- prompt for confirmation when deleting payroll subitems

## Testing
- `npm run lint` *(fails: 112 problems)*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6895b2db4afc832d95142cf4ef6d62ca