### PR TITLE
fix: ensure subitem delete confirmation modal overlays creation modal

### DIFF
--- a/client/src/Admin/pages/Financing/Payroll.tsx
+++ b/client/src/Admin/pages/Financing/Payroll.tsx
@@ -690,7 +690,7 @@ export default function Payroll() {
       )}
       {extraToDelete && (
         <div
-          className="fixed inset-0 bg-black/50 flex items-center justify-center z-60"
+          className="fixed inset-0 bg-black/50 flex items-center justify-center z-[60]"
           onClick={() => setExtraToDelete(null)}
         >
           <div


### PR DESCRIPTION
## Summary
- use Tailwind z-[60] for subitem delete confirmation overlay so it renders above the creation modal

## Testing
- `npm run lint` *(fails: 112 problems)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6895b7bcfc88832d9b11a566efed46ca