### PR TITLE
feat: allow deleting appointment templates

### DIFF
--- a/client/src/Admin/pages/Calendar/components/CreateAppointmentModal.tsx
+++ b/client/src/Admin/pages/Calendar/components/CreateAppointmentModal.tsx
@@ -663,6 +663,22 @@ const preserveTeamRef = useRef(false)
     }
   }
 
+  const deleteTemplate = async () => {
+    if (!selectedTemplate) return
+    const ok = await confirm('Delete this template?')
+    if (!ok) return
+    const res = await fetch(`${API_BASE_URL}/appointment-templates/${selectedTemplate}`, {
+      method: 'DELETE',
+      headers: { "ngrok-skip-browser-warning": "1" },
+    })
+    if (res.ok) {
+      setTemplates((p) => p.filter((tt) => tt.id !== selectedTemplate))
+      resetTemplateRelated()
+    } else {
+      await alert('Failed to delete template')
+    }
+  }
+
   const isValidSelection = () => {
     if (staffOptions.length === 0) return true
     const opt = staffOptions[selectedOption]
@@ -1111,6 +1127,9 @@ const preserveTeamRef = useRef(false)
                     </button>
                     <button className="text-sm text-blue-500" onClick={startEditTemplate}>
                       edit
+                    </button>
+                    <button className="text-sm text-red-500" onClick={deleteTemplate}>
+                      delete
                     </button>
                   </div>
                 </div>

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -801,6 +801,16 @@ app.post('/appointment-templates', async (req: Request, res: Response) => {
   }
 })
 
+app.delete('/appointment-templates/:id', async (req: Request, res: Response) => {
+  const id = parseInt(req.params.id, 10)
+  try {
+    await prisma.appointmentTemplate.delete({ where: { id } })
+    res.json({ ok: true })
+  } catch (e) {
+    res.status(500).json({ error: 'Failed to delete template' })
+  }
+})
+
 // Staff options lookup
 app.get('/staff-options', (req: Request, res: Response) => {
   const size = String(req.query.size || '')


### PR DESCRIPTION
## Summary
- add API endpoint to remove appointment templates
- allow deletion of selected appointment templates via UI

## Testing
- `npm test` (server) *(fails: Error: no test specified)*
- `npm run build` (server)
- `npm test` (client) *(fails: Missing script "test")*
- `npm run lint` (client) *(fails: 112 problems)*

------
https://chatgpt.com/codex/tasks/task_e_689e8511f63c832d916076f74bf65b08